### PR TITLE
Fixing run pending finalizers

### DIFF
--- a/julia/mmtk_julia.c
+++ b/julia/mmtk_julia.c
@@ -402,23 +402,21 @@ void run_finalizer_function(void *o, void *ff, bool is_ptr)
 
 
 static inline void mmtk_jl_run_finalizers_in_list(bool at_exit) {
-    jl_task_t *ct = jl_current_task;
-    uint8_t sticky = ct->sticky;
     mmtk_run_finalizers(at_exit);
-    ct->sticky = sticky;
 }
 
 void mmtk_jl_run_finalizers(void* ptls) {
     // Only disable finalizers on current thread
     // Doing this on all threads is racy (it's impossible to check
     // or wait for finalizers on other threads without dead lock).
-    if (!((jl_ptls_t)ptls)->in_finalizer && !((jl_ptls_t)ptls)->finalizers_inhibited && ((jl_ptls_t)ptls)->locks.len == 0) {
+    if (!((jl_ptls_t)ptls)->finalizers_inhibited && ((jl_ptls_t)ptls)->locks.len == 0) {
         jl_task_t *ct = jl_current_task;
         int8_t was_in_finalizer = ((jl_ptls_t)ptls)->in_finalizer;
         ((jl_ptls_t)ptls)->in_finalizer = 1;
         uint64_t save_rngState[4];
         memcpy(&save_rngState[0], &ct->rngState[0], sizeof(save_rngState));
         jl_rng_split(ct->rngState, finalizer_rngState);
+        jl_atomic_store_relaxed(&jl_gc_have_pending_finalizers, 0);
         mmtk_jl_run_finalizers_in_list(false);
         memcpy(&ct->rngState[0], &save_rngState[0], sizeof(save_rngState));
         ((jl_ptls_t)ptls)->in_finalizer = was_in_finalizer;

--- a/julia/mmtk_julia.h
+++ b/julia/mmtk_julia.h
@@ -29,4 +29,6 @@ void mmtk_jl_gc_run_all_finalizers(void);
 
 void mmtk_jl_run_finalizers(void* tls);
 
+void mmtk_jl_run_pending_finalizers(void* tls);
+
 JL_DLLEXPORT void scan_julia_obj(void* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -317,12 +317,12 @@ pub extern "C" fn run_finalizers_for_obj(obj: ObjectReference) {
     }
 
     for obj in finalizable_objs {
-        unsafe { ((*UPCALLS).run_finalizer_function)(obj.0, obj.1, obj.2) }
         {
             let mut fin_roots = FINALIZER_ROOTS.write().unwrap();
             let removed = fin_roots.remove(&obj);
             assert!(removed);
         }
+        unsafe { ((*UPCALLS).run_finalizer_function)(obj.0, obj.1, obj.2) }
     }
 
     if !finalizers_running {

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -177,22 +177,7 @@ pub extern "C" fn mmtk_run_finalizers(at_exit: bool) {
             let to_be_finalized = memory_manager::get_finalized_object(&SINGLETON);
 
             match to_be_finalized {
-                Some(obj) => {
-                    // if the finalizer function triggers GC you don't want the object to be GC-ed
-                    {
-                        let mut fin_roots = FINALIZER_ROOTS.write().unwrap();
-                        let inserted = fin_roots.insert(obj);
-                        assert!(inserted);
-                    }
-
-                    unsafe { ((*UPCALLS).run_finalizer_function)(obj.0, obj.1, obj.2) }
-
-                    {
-                        let mut fin_roots = FINALIZER_ROOTS.write().unwrap();
-                        let removed = fin_roots.remove(&obj);
-                        assert!(removed);
-                    }
-                }
+                Some(obj) => unsafe { ((*UPCALLS).run_finalizer_function)(obj.0, obj.1, obj.2) },
                 None => break,
             }
         }

--- a/mmtk/src/reference_glue.rs
+++ b/mmtk/src/reference_glue.rs
@@ -24,7 +24,8 @@ impl Finalizable for JuliaFinalizableObject {
     }
     fn keep_alive<E: ProcessEdgesWork>(&mut self, trace: &mut E) {
         self.set_reference(trace.trace_object(self.get_reference()));
-        if !self.2 { // not a void pointer
+        if !self.2 {
+            // not a void pointer
             trace.trace_object(ObjectReference::from_raw_address(self.1));
         }
     }

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -56,7 +56,8 @@ impl Scanning<JuliaVM> for VMScanning {
 
         // processing finalizer roots
         for obj in fin_roots.iter() {
-            if !obj.2 { // not a void pointer
+            if !obj.2 {
+                // not a void pointer
                 let obj_ref = ObjectReference::from_raw_address((*obj).1);
                 roots_to_scan.push(obj_ref);
             }


### PR DESCRIPTION
Copy implementation for running pending finalisers from stock Julia. This should fix the tests:
```
Error in testset dict:
Test Failed at test/dict.jl:944
  Expression: isempty(d26939)
   Evaluated: isempty(WeakKeyDict{Any, Any}())
Error in testset dict:
Test Failed at test/dict.jl:945
  Expression: length(d26939.ht) == 0
   Evaluated: 8 == 0
Error in testset dict:
Test Failed at test/dict.jl:946
  Expression: length(d26939) == 0
   Evaluated: 8 == 0
```