### PR TITLE
Fix/object allocation

### DIFF
--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -75,6 +75,10 @@ extern "C" {
     pub static BI_METADATA_END_ALIGNED_UP: usize;
 }
 
+#[cfg(feature = "immix")]
+#[no_mangle]
+pub static MAX_IMMIX_OBJECT_SIZE : usize = mmtk::plan::IMMIX_CONSTRAINTS.max_non_los_default_alloc_bytes;
+
 #[no_mangle]
 pub static BLOCK_FOR_GC: AtomicBool = AtomicBool::new(false);
 

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -77,7 +77,13 @@ extern "C" {
 
 #[cfg(feature = "immix")]
 #[no_mangle]
-pub static MAX_IMMIX_OBJECT_SIZE : usize = mmtk::plan::IMMIX_CONSTRAINTS.max_non_los_default_alloc_bytes;
+pub static MAX_STANDARD_OBJECT_SIZE: usize =
+    mmtk::plan::IMMIX_CONSTRAINTS.max_non_los_default_alloc_bytes;
+
+#[cfg(not(feature = "immix"))]
+#[no_mangle]
+pub static MAX_STANDARD_OBJECT_SIZE: usize = // default to size of Julia's max size class
+    2032 - std::mem::size_of::<Address>();
 
 #[no_mangle]
 pub static BLOCK_FOR_GC: AtomicBool = AtomicBool::new(false);

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -67,7 +67,13 @@ impl ObjectModel<JuliaVM> for VMObjectModel {
     }
 
     fn get_current_size(object: ObjectReference) -> usize {
-        let size =  unsafe { ((*UPCALLS).get_so_size)(object) };
+        let size = if is_object_in_los(&object) {
+            unsafe { ((*UPCALLS).get_lo_size)(object) }
+        } else {
+            let obj_size = unsafe { ((*UPCALLS).get_so_size)(object) };
+            obj_size
+        };
+
         size as usize
     }
 
@@ -93,7 +99,12 @@ impl ObjectModel<JuliaVM> for VMObjectModel {
 
     #[inline(always)]
     fn ref_to_object_start(object: ObjectReference) -> Address {
-        unsafe { ((*UPCALLS).get_object_start_ref)(object) }
+        let res = if is_object_in_los(&object) {
+            object.to_raw_address() - 48
+        } else {
+            unsafe { ((*UPCALLS).get_object_start_ref)(object) }
+        };
+        res
     }
 
     #[inline(always)]
@@ -114,6 +125,10 @@ impl ObjectModel<JuliaVM> for VMObjectModel {
     fn dump_object(_object: ObjectReference) {
         unimplemented!()
     }
+}
+
+pub fn is_object_in_los(object: &ObjectReference) -> bool {
+    (*object).to_raw_address().as_usize() > 0x60000000000
 }
 
 #[no_mangle]

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -67,13 +67,7 @@ impl ObjectModel<JuliaVM> for VMObjectModel {
     }
 
     fn get_current_size(object: ObjectReference) -> usize {
-        let size = if is_object_in_los(&object) {
-            unsafe { ((*UPCALLS).get_lo_size)(object) }
-        } else {
-            let obj_size = unsafe { ((*UPCALLS).get_so_size)(object) };
-            obj_size
-        };
-
+        let size =  unsafe { ((*UPCALLS).get_so_size)(object) };
         size as usize
     }
 
@@ -99,12 +93,7 @@ impl ObjectModel<JuliaVM> for VMObjectModel {
 
     #[inline(always)]
     fn ref_to_object_start(object: ObjectReference) -> Address {
-        let res = if is_object_in_los(&object) {
-            object.to_raw_address() - 48
-        } else {
-            unsafe { ((*UPCALLS).get_object_start_ref)(object) }
-        };
-        res
+        unsafe { ((*UPCALLS).get_object_start_ref)(object) }
     }
 
     #[inline(always)]
@@ -125,10 +114,6 @@ impl ObjectModel<JuliaVM> for VMObjectModel {
     fn dump_object(_object: ObjectReference) {
         unimplemented!()
     }
-}
-
-pub fn is_object_in_los(object: &ObjectReference) -> bool {
-    (*object).to_raw_address().as_usize() > 0x60000000000
 }
 
 #[no_mangle]


### PR DESCRIPTION
This PR changes the threshold for allocation Julia's large objects to follow immix's threshold. While this probably brings a benefit in terms of allocation (more objects can be allocated via fastpath), until `get_so_size` is optimised, changing the threshold can actually degrade performance, since getting the objects size of large objects is way less expensive (loading a field from the header) than getting the size of small objects (check the object type, and calculate the size based on that). 