### PR TITLE
Remove some warnings when compiling Julia

### DIFF
--- a/julia/mmtk_julia.c
+++ b/julia/mmtk_julia.c
@@ -171,7 +171,7 @@ static void mmtk_sweep_malloced_arrays(void) JL_NOTSAFEPOINT
 extern void mark_metadata_scanned(jl_value_t* obj);
 extern int8_t check_metadata_scanned(jl_value_t* obj);
 
-int8_t object_has_been_scanned(void* obj)
+int8_t object_has_been_scanned(jl_value_t* obj)
 {
     uintptr_t tag = (uintptr_t)jl_typeof(obj);
     jl_datatype_t *vt = (jl_datatype_t*)tag;
@@ -188,7 +188,7 @@ int8_t object_has_been_scanned(void* obj)
     return 0;
 }
 
-void mark_object_as_scanned(void* obj) {
+void mark_object_as_scanned(jl_value_t* obj) {
     if (jl_object_in_image((jl_value_t *)obj)) {
         jl_taggedvalue_t *o = jl_astaggedvalue(obj);
         o->bits.gc = GC_MARKED;
@@ -209,7 +209,7 @@ void mmtk_exit_from_safepoint(int8_t old_state) {
 // it will block until GC is done
 // that thread simply exits from block_for_gc without executing finalizers
 // when executing finalizers do not let another thread do GC (set a variable such that while that variable is true, no GC can be done)
-int8_t set_gc_initial_state(void* ptls) 
+int8_t set_gc_initial_state(jl_ptls_t ptls) 
 {
     int8_t old_state = jl_atomic_load_relaxed(&((jl_ptls_t)ptls)->gc_state);
     jl_atomic_store_release(&((jl_ptls_t)ptls)->gc_state, JL_GC_STATE_WAITING);
@@ -277,7 +277,7 @@ int get_jl_last_err(void)
     return errno;
 }
 
-void* get_obj_start_ref(void* obj) 
+void* get_obj_start_ref(jl_value_t* obj) 
 {
     uintptr_t tag = (uintptr_t)jl_typeof(obj);
     jl_datatype_t *vt = (jl_datatype_t*)tag;
@@ -292,7 +292,7 @@ void* get_obj_start_ref(void* obj)
     return obj_start_ref;
 }
 
-size_t get_so_size(void* obj) 
+size_t get_so_size(jl_value_t* obj) 
 {
     uintptr_t tag = (uintptr_t)jl_typeof(obj);
     jl_datatype_t *vt = (jl_datatype_t*)tag;
@@ -413,7 +413,7 @@ size_t get_so_size(void* obj)
     return 0;
 }
 
-void run_finalizer_function(void *o, void *ff, bool is_ptr)
+void run_finalizer_function(jl_value_t *o, jl_value_t *ff, bool is_ptr)
 {
     if (is_ptr) {
         run_finalizer(jl_current_task, (jl_value_t *)(((uintptr_t)o) | 1), (jl_value_t *)ff);
@@ -444,7 +444,7 @@ void mmtk_jl_run_pending_finalizers(void* ptls) {
     }
 }
 
-void mmtk_jl_run_finalizers(void* ptls) {
+void mmtk_jl_run_finalizers(jl_ptls_t ptls) {
     // Only disable finalizers on current thread
     // Doing this on all threads is racy (it's impossible to check
     // or wait for finalizers on other threads without dead lock).
@@ -583,7 +583,7 @@ static inline uintptr_t mmtk_gc_read_stack(void *_addr, uintptr_t offset,
     return *(uintptr_t*)real_addr;
 }
 
-JL_DLLEXPORT void scan_julia_exc_obj(void* obj, closure_pointer closure, ProcessEdgeFn process_edge) {
+JL_DLLEXPORT void scan_julia_exc_obj(jl_task_t* obj, closure_pointer closure, ProcessEdgeFn process_edge) {
     jl_task_t *ta = (jl_task_t*)obj;
 
     if (ta->excstack) { // inlining label `excstack` from mark_loop
@@ -644,7 +644,7 @@ JL_DLLEXPORT void* get_stackbase(int16_t tid) {
  * directly (not an edge), specifying whether to scan the object or not; and only scan the object 
  * (necessary for boot image / non-MMTk objects)
 **/
-JL_DLLEXPORT void scan_julia_obj(void* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge) 
+JL_DLLEXPORT void scan_julia_obj(jl_value_t* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge) 
 {
     uintptr_t tag = (uintptr_t)jl_typeof(obj);
     jl_datatype_t *vt = (jl_datatype_t*)tag; // type of obj
@@ -934,8 +934,26 @@ JL_DLLEXPORT void scan_julia_obj(void* obj, closure_pointer closure, ProcessEdge
     return;
 }
 
-Julia_Upcalls mmtk_upcalls = { scan_julia_obj, scan_julia_exc_obj, get_stackbase, calculate_roots, run_finalizer_function, get_jl_last_err, set_jl_last_err, get_lo_size,
-                               get_so_size, get_obj_start_ref, wait_for_the_world, set_gc_initial_state, set_gc_final_state, set_gc_old_state, mmtk_jl_run_finalizers,
-                               jl_throw_out_of_memory_error, mark_object_as_scanned, object_has_been_scanned, mmtk_sweep_malloced_arrays,
-                               mmtk_wait_in_a_safepoint, mmtk_exit_from_safepoint
-                             };
+Julia_Upcalls mmtk_upcalls = (Julia_Upcalls) {
+    .scan_julia_obj = scan_julia_obj,
+    .scan_julia_exc_obj = scan_julia_exc_obj,
+    .get_stackbase = get_stackbase,
+    .calculate_roots = calculate_roots,
+    .run_finalizer_function = run_finalizer_function,
+    .get_jl_last_err = get_jl_last_err,
+    .set_jl_last_err = set_jl_last_err,
+    .get_lo_size = get_lo_size,
+    .get_so_size = get_so_size,
+    .get_obj_start_ref = get_obj_start_ref,
+    .wait_for_the_world = wait_for_the_world,
+    .set_gc_initial_state = set_gc_initial_state,
+    .set_gc_final_state = set_gc_final_state,
+    .set_gc_old_state = set_gc_old_state,
+    .mmtk_jl_run_finalizers = mmtk_jl_run_finalizers,
+    .jl_throw_out_of_memory_error = jl_throw_out_of_memory_error,
+    .mark_object_as_scanned = mark_object_as_scanned,
+    .object_has_been_scanned = object_has_been_scanned,
+    .sweep_malloced_array = mmtk_sweep_malloced_arrays,
+    .wait_in_a_safepoint = mmtk_wait_in_a_safepoint,
+    .exit_from_safepoint = mmtk_exit_from_safepoint,
+};

--- a/julia/mmtk_julia.h
+++ b/julia/mmtk_julia.h
@@ -7,9 +7,9 @@ void calculate_roots(jl_ptls_t ptls);
 
 void run_finalizer_function(void *o, void *ff, bool is_ptr);
 
-uintptr_t get_jl_last_err(void);
+int get_jl_last_err(void);
 
-void set_jl_last_err(uintptr_t e);
+void set_jl_last_err(int e);
 
 size_t get_lo_size(bigval_t obj);
 

--- a/julia/mmtk_julia.h
+++ b/julia/mmtk_julia.h
@@ -5,7 +5,7 @@ extern Julia_Upcalls mmtk_upcalls;
 
 void calculate_roots(jl_ptls_t ptls);
 
-void run_finalizer_function(void *o, void *ff, bool is_ptr);
+void run_finalizer_function(jl_value_t *o, jl_value_t *ff, bool is_ptr);
 
 int get_jl_last_err(void);
 
@@ -13,7 +13,7 @@ void set_jl_last_err(int e);
 
 size_t get_lo_size(bigval_t obj);
 
-int8_t set_gc_initial_state(void* ptls);
+int8_t set_gc_initial_state(jl_ptls_t ptls);
 
 void set_gc_final_state(int8_t old_state);
 
@@ -21,14 +21,14 @@ int set_gc_running_state(jl_ptls_t ptls);
 
 void set_gc_old_state(int8_t old_state);
 
-void mark_object_as_scanned(void* obj);
+void mark_object_as_scanned(jl_value_t* obj);
 
-int8_t object_has_been_scanned(void* obj);
+int8_t object_has_been_scanned(jl_value_t* obj);
 
 void mmtk_jl_gc_run_all_finalizers(void);
 
-void mmtk_jl_run_finalizers(void* tls);
+void mmtk_jl_run_finalizers(jl_ptls_t tls);
 
 void mmtk_jl_run_pending_finalizers(void* tls);
 
-JL_DLLEXPORT void scan_julia_obj(void* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);
+JL_DLLEXPORT void scan_julia_obj(jl_value_t* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -84,6 +84,9 @@ extern void* trace_retain_referent(MMTk_TraceLocal trace_local, void* obj);
  * Julia-specific
  */
 
+// When we call upcalls from Rust, we assume:
+// * int is 4 bytes
+// * size_t is 8 bytes
 typedef struct {
     void (* scan_julia_obj) (jl_value_t* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);
     void (* scan_julia_exc_obj) (jl_task_t* obj, closure_pointer closure, ProcessEdgeFn process_edge);

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -38,6 +38,8 @@ extern void* alloc_large(MMTk_Mutator mutator, size_t size,
 extern void post_alloc(MMTk_Mutator mutator, void* refer,
     int bytes, int allocator);
 
+extern void add_object_to_mmtk_roots(void *obj);
+
 extern void* mmtk_counted_malloc(size_t size);
 extern void* mmtk_malloc(size_t size);
 extern void* mmtk_counted_calloc(size_t n, size_t size);
@@ -54,7 +56,7 @@ extern bool is_mapped_object(void* ref);
 extern bool is_mapped_address(void* addr);
 extern void modify_check(void* ref);
 extern int object_is_managed_by_mmtk(void* addr);
-extern void runtime_panic();
+extern void runtime_panic(void);
 
 
 
@@ -87,7 +89,7 @@ typedef struct {
     void (* calculate_roots) (void* tls);
     void (* run_finalizer_function) (void* obj, void* function, bool is_ptr);
     void (* get_jl_last_err) (void);
-    void (* set_jl_last_err) (int errno);
+    void (* set_jl_last_err) (int e);
     void (* get_lo_size) (void* obj);
     void (* get_so_size) (void* obj, size_t actual_size);
     void (* get_obj_start_ref) (void* obj);
@@ -96,12 +98,12 @@ typedef struct {
     void (* set_gc_final_state) (int old_state);
     void (* set_gc_old_state) (int old_state);
     void (* mmtk_jl_run_finalizers) (void* tls);
-    void (* jl_throw_out_of_memory_error) ();
+    void (* jl_throw_out_of_memory_error) (void);
     void (* mark_object_as_scanned) (void* obj);
     void (* object_has_been_scanned) (void* obj);
-    void (* sweep_malloced_array) ();
+    void (* sweep_malloced_array) (void);
     void (* get_malloced_bytes) (void* tls);
-    void (* wait_in_a_safepoint) ();
+    void (* wait_in_a_safepoint) (void);
     void (* exit_from_safepoint) (int old_state);
 } Julia_Upcalls;
 

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+#include "gc.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -83,28 +85,28 @@ extern void* trace_retain_referent(MMTk_TraceLocal trace_local, void* obj);
  */
 
 typedef struct {
-    void (* scan_julia_obj) (void* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);
-    void (* scan_julia_exc_obj) (void* obj, closure_pointer closure, ProcessEdgeFn process_edge);
-    void (* get_stackbase) (int tid);
-    void (* calculate_roots) (void* tls);
-    void (* run_finalizer_function) (void* obj, void* function, bool is_ptr);
-    void (* get_jl_last_err) (void);
+    void (* scan_julia_obj) (jl_value_t* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);
+    void (* scan_julia_exc_obj) (jl_task_t* obj, closure_pointer closure, ProcessEdgeFn process_edge);
+    void* (* get_stackbase) (int16_t tid);
+    void (* calculate_roots) (jl_ptls_t tls);
+    void (* run_finalizer_function) (jl_value_t* obj, jl_value_t* function, bool is_ptr);
+    int (* get_jl_last_err) (void);
     void (* set_jl_last_err) (int e);
-    void (* get_lo_size) (void* obj);
-    void (* get_so_size) (void* obj, size_t actual_size);
-    void (* get_obj_start_ref) (void* obj);
+    // FIXME: I don't think this is correct, as we pass an object reference to get_lo_size, in the same way as get_so_size.
+    size_t (* get_lo_size) (bigval_t obj);
+    size_t (* get_so_size) (jl_value_t* obj);
+    void* (* get_obj_start_ref) (jl_value_t* obj);
     void (* wait_for_the_world) (void);
-    void (* set_gc_initial_state) (void* tls);
-    void (* set_gc_final_state) (int old_state);
-    void (* set_gc_old_state) (int old_state);
-    void (* mmtk_jl_run_finalizers) (void* tls);
+    int8_t (* set_gc_initial_state) (jl_ptls_t tls);
+    void (* set_gc_final_state) (int8_t old_state);
+    void (* set_gc_old_state) (int8_t old_state);
+    void (* mmtk_jl_run_finalizers) (jl_ptls_t tls);
     void (* jl_throw_out_of_memory_error) (void);
-    void (* mark_object_as_scanned) (void* obj);
-    void (* object_has_been_scanned) (void* obj);
+    void (* mark_object_as_scanned) (jl_value_t* obj);
+    int8_t (* object_has_been_scanned) (jl_value_t* obj);
     void (* sweep_malloced_array) (void);
-    void (* get_malloced_bytes) (void* tls);
     void (* wait_in_a_safepoint) (void);
-    void (* exit_from_safepoint) (int old_state);
+    void (* exit_from_safepoint) (int8_t old_state);
 } Julia_Upcalls;
 
 /**

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -135,14 +135,14 @@ pub struct Julia_Upcalls {
         closure: &mut dyn EdgeVisitor<JuliaVMEdge>,
         process_edge: ProcessEdgeFn,
     ),
-    pub get_stackbase: extern "C" fn(tid: u16) -> u64,
+    pub get_stackbase: extern "C" fn(tid: u16) -> usize,
     pub calculate_roots: extern "C" fn(tls: OpaquePointer),
     pub run_finalizer_function:
         extern "C" fn(obj: ObjectReference, function: Address, is_ptr: bool),
-    pub get_jl_last_err: extern "C" fn() -> u64,
-    pub set_jl_last_err: extern "C" fn(errno: u64),
-    pub get_lo_size: extern "C" fn(object: ObjectReference) -> u64,
-    pub get_so_size: extern "C" fn(object: ObjectReference) -> u64,
+    pub get_jl_last_err: extern "C" fn() -> u32,
+    pub set_jl_last_err: extern "C" fn(errno: u32),
+    pub get_lo_size: extern "C" fn(object: ObjectReference) -> usize,
+    pub get_so_size: extern "C" fn(object: ObjectReference) -> usize,
     pub get_object_start_ref: extern "C" fn(object: ObjectReference) -> Address,
     pub wait_for_the_world: extern "C" fn(),
     pub set_gc_initial_state: extern "C" fn(tls: OpaquePointer) -> i8,
@@ -153,7 +153,7 @@ pub struct Julia_Upcalls {
     pub mark_julia_object_as_scanned: extern "C" fn(obj: Address),
     pub julia_object_has_been_scanned: extern "C" fn(obj: Address) -> u8,
     pub mmtk_sweep_malloced_array: extern "C" fn(),
-    pub wait_in_a_safepoint: extern "C" fn() -> i8,
+    pub wait_in_a_safepoint: extern "C" fn(),
     pub exit_from_safepoint: extern "C" fn(old_state: i8),
 }
 


### PR DESCRIPTION
There are also numerous warnings coming from the definition of `mmtk_upcalls` that I haven't fixed.