### PR TITLE
Keep roots until end of GC

### DIFF
--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -85,6 +85,7 @@ impl Collection<JuliaVM> for VMCollection {
         }
 
         info!("GC Done!");
+        crate::ROOTS.lock().unwrap().clear();
         if AtomicBool::load(&USER_TRIGGERED_GC, Ordering::SeqCst) {
             AtomicBool::store(&USER_TRIGGERED_GC, false, Ordering::SeqCst);
         }

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -40,13 +40,13 @@ impl Scanning<JuliaVM> for VMScanning {
         _tls: VMWorkerThread,
         mut factory: impl RootsWorkFactory<JuliaVMEdge>,
     ) {
-        let mut roots: MutexGuard<HashSet<Address>> = ROOTS.lock().unwrap();
+        let roots: MutexGuard<HashSet<Address>> = ROOTS.lock().unwrap();
         info!("{} thread roots", roots.len());
 
         let mut roots_to_scan = vec![];
 
-        for obj in roots.drain() {
-            let obj_ref = ObjectReference::from_raw_address(obj);
+        for obj in roots.iter() {
+            let obj_ref = ObjectReference::from_raw_address(*obj);
             roots_to_scan.push(obj_ref);
         }
 


### PR DESCRIPTION
We currently iterate the roots at the beginning of GC when MMTk requires roots, and we drain the roots. This does not work with MMTk sanity GC or other GC plans that may request root scanning again. This PR keeps the roots until the end of GC, and clear the root set at the end of GC.