### PR TITLE
Update to mmtk-core PR #838

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=de8bbfe623eee5e915f32870de8f81128df8ad41#de8bbfe623eee5e915f32870de8f81128df8ad41"
+source = "git+https://github.com/fepicture/mmtk-core.git?rev=b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af#b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af"
 dependencies = [
  "atomic 0.5.1",
  "atomic-traits",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=de8bbfe623eee5e915f32870de8f81128df8ad41#de8bbfe623eee5e915f32870de8f81128df8ad41"
+source = "git+https://github.com/fepicture/mmtk-core.git?rev=b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af#b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/fepicture/mmtk-core.git?rev=b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af#b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0#2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0"
 dependencies = [
  "atomic 0.5.1",
  "atomic-traits",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/fepicture/mmtk-core.git?rev=b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af#b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0#2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI
-mmtk = { git = "https://github.com/fepicture/mmtk-core.git", rev = "b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] }

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "de8bbfe623eee5e915f32870de8f81128df8ad41" }
+mmtk = { git = "https://github.com/fepicture/mmtk-core.git", rev = "b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] }

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -135,7 +135,7 @@ pub extern "C" fn alloc(
     mutator: *mut Mutator<JuliaVM>,
     size: usize,
     align: usize,
-    offset: isize,
+    offset: usize,
     semantics: AllocationSemantics,
 ) -> Address {
     memory_manager::alloc::<JuliaVM>(unsafe { &mut *mutator }, size, align, offset, semantics)
@@ -146,7 +146,7 @@ pub extern "C" fn alloc_large(
     mutator: *mut Mutator<JuliaVM>,
     size: usize,
     align: usize,
-    offset: isize,
+    offset: usize,
 ) -> Address {
     memory_manager::alloc::<JuliaVM>(
         unsafe { &mut *mutator },

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -66,7 +66,7 @@ impl ObjectModel<JuliaVM> for VMObjectModel {
         unimplemented!()
     }
 
-    fn get_align_offset_when_copied(_object: ObjectReference) -> isize {
+    fn get_align_offset_when_copied(_object: ObjectReference) -> usize {
         unimplemented!()
     }
 


### PR DESCRIPTION
This PR updates mmtk-core to https://github.com/mmtk/mmtk-core/pull/838.