### PR TITLE
Embed mutator in _jl_tls_states_t

### DIFF
--- a/julia/mmtk_julia.c
+++ b/julia/mmtk_julia.c
@@ -259,6 +259,8 @@ int get_jl_last_err(void)
         printf("Check thread local cursor/limit for ptls: %p\n", ptls); fflush(stdout);
         assert(ptls->mmtk_mutator.allocators.immix[0].cursor == 0);
         assert(ptls->mmtk_mutator.allocators.immix[0].limit == 0);
+        assert(ptls->mmtk_mutator.allocators.immix[0].large_cursor == 0);
+        assert(ptls->mmtk_mutator.allocators.immix[0].large_limit == 0);
     }
 
     return errno;
@@ -971,7 +973,7 @@ void update_gc_time(uint64_t inc) {
 }
 
 uintptr_t get_abi_structs_checksum_c(void) {
-    printf("hi");
+    // printf("hi");
     return sizeof(MMTkMutatorContext);
 }
 

--- a/julia/mmtk_julia.h
+++ b/julia/mmtk_julia.h
@@ -3,17 +3,9 @@
 
 extern Julia_Upcalls mmtk_upcalls;
 
-void calculate_roots(jl_ptls_t ptls);
-
-void run_finalizer_function(jl_value_t *o, jl_value_t *ff, bool is_ptr);
-
 int get_jl_last_err(void);
 
 void set_jl_last_err(int e);
-
-size_t get_lo_size(bigval_t obj);
-
-int8_t set_gc_initial_state(jl_ptls_t ptls);
 
 void set_gc_final_state(int8_t old_state);
 
@@ -21,14 +13,6 @@ int set_gc_running_state(jl_ptls_t ptls);
 
 void set_gc_old_state(int8_t old_state);
 
-void mark_object_as_scanned(jl_value_t* obj);
-
-int8_t object_has_been_scanned(jl_value_t* obj);
-
 void mmtk_jl_gc_run_all_finalizers(void);
 
-void mmtk_jl_run_finalizers(jl_ptls_t tls);
-
 void mmtk_jl_run_pending_finalizers(void* tls);
-
-JL_DLLEXPORT void scan_julia_obj(jl_value_t* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -545,7 +545,6 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0#2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0"
 dependencies = [
  "atomic 0.5.1",
  "atomic-traits",
@@ -590,7 +589,6 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0#2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0#2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0"
 dependencies = [
  "atomic 0.5.1",
  "atomic-traits",
@@ -589,6 +590,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0#2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/qinsoon/julia.git"
-julia_version = "953583c78ca16383cc5de43e9b342cdcc6696823"
+julia_repo = "https://github.com/mmtk/julia.git"
+julia_version = "98a66ba3c0925ea21bfe051a191210eeae7df0f2"
 
 [lib]
 crate-type = ["staticlib", "rlib", "dylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/qinsoon/julia.git"
-julia_version = "e0ff499fed9797529a8efedcc3799a7f9cfb771b"
+julia_version = "953583c78ca16383cc5de43e9b342cdcc6696823"
 
 [lib]
 crate-type = ["staticlib", "rlib", "dylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/qinsoon/julia.git"
-julia_version = "94118df6a3a6a675931a20ff63bda0d47674215e"
+julia_version = "e0ff499fed9797529a8efedcc3799a7f9cfb771b"
 
 [lib]
 crate-type = ["staticlib", "rlib", "dylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "0eeb64b0191b08b0ce7b59a66dea6139db60dbd2"
+julia_repo = "https://github.com/qinsoon/julia.git"
+julia_version = "94118df6a3a6a675931a20ff63bda0d47674215e"
 
 [lib]
 crate-type = ["staticlib", "rlib", "dylib"]
@@ -29,9 +29,9 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI
-# mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0" }
 # Uncomment the following to build locally
-mmtk = { path = "/home/yilin/mmtk-core" }
+# mmtk = { path = "../repos/mmtk-core" }
 log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
 enum-map = ">=2.1"
 atomic = "0.4.6"

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,9 +29,9 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0" }
+# mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0" }
 # Uncomment the following to build locally
-# mmtk = { path = "../repos/mmtk-core" }
+mmtk = { path = "/home/yilin/mmtk-core" }
 log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
 enum-map = ">=2.1"
 atomic = "0.4.6"

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -23,7 +23,7 @@ typedef void (*ProcessOffsetEdgeFn)(closure_pointer closure, void* slot, int off
  * Allocation
  */
 extern MMTk_Mutator mmtk_bind_mutator(void *tls, int tid);
-extern void mmtk_add_mutator_ref(void* mutator_ref);
+extern void mmtk_post_bind_mutator(MMTk_Mutator mutator, MMTk_Mutator original_mutator);
 extern void mmtk_destroy_mutator(MMTk_Mutator mutator);
 
 extern void* mmtk_alloc(MMTk_Mutator mutator, size_t size,

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include "gc.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,30 +77,31 @@ extern const void* MMTK_SIDE_LOG_BIT_BASE_ADDRESS;
 // * int is 4 bytes
 // * size_t is 8 bytes
 typedef struct {
-    void (* scan_julia_obj) (jl_value_t* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);
-    void (* scan_julia_exc_obj) (jl_task_t* obj, closure_pointer closure, ProcessEdgeFn process_edge);
+    void (* scan_julia_obj) (void* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);
+    void (* scan_julia_exc_obj) (void* obj, closure_pointer closure, ProcessEdgeFn process_edge);
     void* (* get_stackbase) (int16_t tid);
-    void (* calculate_roots) (jl_ptls_t tls);
-    void (* run_finalizer_function) (jl_value_t* obj, jl_value_t* function, bool is_ptr);
+    void (* calculate_roots) (void* tls);
+    void (* run_finalizer_function) (void* obj, void* function, bool is_ptr);
     int (* get_jl_last_err) (void);
     void (* set_jl_last_err) (int e);
     // FIXME: I don't think this is correct, as we pass an object reference to get_lo_size, in the same way as get_so_size.
-    size_t (* get_lo_size) (bigval_t obj);
-    size_t (* get_so_size) (jl_value_t* obj);
-    void* (* get_obj_start_ref) (jl_value_t* obj);
+    size_t (* get_lo_size) (void* obj);
+    size_t (* get_so_size) (void* obj);
+    void* (* get_obj_start_ref) (void* obj);
     void (* wait_for_the_world) (void);
-    int8_t (* set_gc_initial_state) (jl_ptls_t tls);
+    int8_t (* set_gc_initial_state) (void* tls);
     void (* set_gc_final_state) (int8_t old_state);
     void (* set_gc_old_state) (int8_t old_state);
-    void (* mmtk_jl_run_finalizers) (jl_ptls_t tls);
+    void (* mmtk_jl_run_finalizers) (void* tls);
     void (* jl_throw_out_of_memory_error) (void);
-    void (* mark_object_as_scanned) (jl_value_t* obj);
-    int8_t (* object_has_been_scanned) (jl_value_t* obj);
+    void (* mark_object_as_scanned) (void* obj);
+    int8_t (* object_has_been_scanned) (void* obj);
     void (* sweep_malloced_array) (void);
     void (* wait_in_a_safepoint) (void);
     void (* exit_from_safepoint) (int8_t old_state);
     uint64_t (* jl_hrtime) (void);
     void (* update_gc_time) (uint64_t);
+    uintptr_t (* get_abi_structs_checksum_c) (void);
 } Julia_Upcalls;
 
 /**

--- a/mmtk/runtime/runtime_gc_x64.c
+++ b/mmtk/runtime/runtime_gc_x64.c
@@ -5,14 +5,6 @@
 
 long JULIA_HEADER_SIZE = 0;
 
-void* get_mutator_ref(void* mutator) {
-    return mutator;
-}
-
-void* get_mutator_from_ref(void* mutator) {
-    return mutator;
-}
-
 extern void mmtk_start_spawned_worker_thread(void*, void*);
 extern void mmtk_start_spawned_controller_thread(void*, void*);
 

--- a/mmtk/src/active_plan.rs
+++ b/mmtk/src/active_plan.rs
@@ -9,10 +9,10 @@ use mmtk::{plan::ObjectQueue, scheduler::GCWorker, util::ObjectReference};
 
 use std::sync::RwLockReadGuard;
 use std::collections::HashSet;
-use std::collections::hash_set::Iter;
 
 pub struct JuliaMutatorIterator<'a> {
-    guard: RwLockReadGuard<'a, HashSet<Address>>,
+    // We do not use this field, but this lock guard makes sure that no concurrent access to MUTATORS.
+    _guard: RwLockReadGuard<'a, HashSet<Address>>,
     vec: Vec<Address>,
     cursor: usize,
 }
@@ -21,7 +21,7 @@ impl<'a> JuliaMutatorIterator<'a> {
     fn new(guard: RwLockReadGuard<'a, HashSet<Address>>) -> Self {
         let vec = guard.iter().map(|addr| *addr).collect();
         Self {
-            guard,
+            _guard: guard,
             vec,
             cursor: 0,
         }

--- a/mmtk/src/active_plan.rs
+++ b/mmtk/src/active_plan.rs
@@ -1,5 +1,5 @@
 use crate::JuliaVM;
-use crate::{get_mutator_from_ref, MUTATORS, MUTATOR_TLS, SINGLETON};
+use crate::{MUTATORS, SINGLETON};
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::Address;
 use mmtk::vm::ActivePlan;
@@ -8,16 +8,21 @@ use mmtk::Plan;
 use mmtk::{plan::ObjectQueue, scheduler::GCWorker, util::ObjectReference};
 
 use std::sync::RwLockReadGuard;
+use std::collections::HashSet;
+use std::collections::hash_set::Iter;
 
 pub struct JuliaMutatorIterator<'a> {
-    guard: RwLockReadGuard<'a, Vec<ObjectReference>>,
+    guard: RwLockReadGuard<'a, HashSet<Address>>,
+    vec: Vec<Address>,
     cursor: usize,
 }
 
 impl<'a> JuliaMutatorIterator<'a> {
-    fn new(guard: RwLockReadGuard<'a, Vec<ObjectReference>>) -> Self {
+    fn new(guard: RwLockReadGuard<'a, HashSet<Address>>) -> Self {
+        let vec = guard.iter().map(|addr| *addr).collect();
         Self {
-            guard: guard,
+            guard,
+            vec,
             cursor: 0,
         }
     }
@@ -27,20 +32,10 @@ impl<'a> Iterator for JuliaMutatorIterator<'a> {
     type Item = &'a mut Mutator<JuliaVM>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let ref mutators = self.guard;
-
         let mutator_idx = self.cursor;
         self.cursor += 1;
-
-        let mutator = mutators.get(mutator_idx);
-
-        match mutator {
-            Some(m) => {
-                let mutator = unsafe { get_mutator_from_ref(*m) };
-                Some(unsafe { &mut *mutator })
-            }
-            None => None,
-        }
+        
+        self.vec.get(mutator_idx).map(|addr| unsafe { &mut *(addr.to_mut_ptr::<Mutator<JuliaVM>>()) })
     }
 }
 
@@ -57,12 +52,7 @@ impl ActivePlan<JuliaVM> for VMActivePlan {
 
     fn is_mutator(tls: VMThread) -> bool {
         // FIXME have a tls field to check whether it is a mutator tls
-        let tls_str = format!("{:?}", tls);
-        let is_mutator = MUTATOR_TLS.read().unwrap().contains(&tls_str);
-        if !is_mutator {
-            println!("Is the tls {:?} a mutator? {}", tls_str, is_mutator);
-        }
-        is_mutator
+        MUTATORS.read().unwrap().iter().find(|mutator_addr| unsafe { &*mutator_addr.to_mut_ptr::<Mutator<JuliaVM>>() }.mutator_tls.0 == tls).is_some()
     }
 
     fn mutator(_tls: VMMutatorThread) -> &'static mut Mutator<JuliaVM> {

--- a/mmtk/src/active_plan.rs
+++ b/mmtk/src/active_plan.rs
@@ -7,8 +7,8 @@ use mmtk::Mutator;
 use mmtk::Plan;
 use mmtk::{plan::ObjectQueue, scheduler::GCWorker, util::ObjectReference};
 
-use std::sync::RwLockReadGuard;
 use std::collections::HashSet;
+use std::sync::RwLockReadGuard;
 
 pub struct JuliaMutatorIterator<'a> {
     // We do not use this field, but this lock guard makes sure that no concurrent access to MUTATORS.
@@ -34,8 +34,10 @@ impl<'a> Iterator for JuliaMutatorIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let mutator_idx = self.cursor;
         self.cursor += 1;
-        
-        self.vec.get(mutator_idx).map(|addr| unsafe { &mut *(addr.to_mut_ptr::<Mutator<JuliaVM>>()) })
+
+        self.vec
+            .get(mutator_idx)
+            .map(|addr| unsafe { &mut *(addr.to_mut_ptr::<Mutator<JuliaVM>>()) })
     }
 }
 

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -42,6 +42,9 @@ pub extern "C" fn mmtk_gc_init(
         set_julia_obj_header_size(header_size);
     };
 
+    // Assert to make sure our ABI is correct
+    assert_eq!(unsafe { ((*UPCALLS).get_abi_structs_checksum_c)() }, crate::util::get_abi_structs_checksum_rust());
+
     {
         let mut builder = BUILDER.lock().unwrap();
 

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -10,8 +10,8 @@ use crate::JULIA_HEADER_SIZE;
 use crate::SINGLETON;
 use crate::UPCALLS;
 use crate::{
-    set_julia_obj_header_size, BUILDER, DISABLED_GC,
-    FINALIZERS_RUNNING, MUTATORS, USER_TRIGGERED_GC,
+    set_julia_obj_header_size, BUILDER, DISABLED_GC, FINALIZERS_RUNNING, MUTATORS,
+    USER_TRIGGERED_GC,
 };
 use crate::{ROOT_EDGES, ROOT_NODES};
 
@@ -41,7 +41,10 @@ pub extern "C" fn mmtk_gc_init(
     };
 
     // Assert to make sure our ABI is correct
-    assert_eq!(unsafe { ((*UPCALLS).get_abi_structs_checksum_c)() }, crate::util::get_abi_structs_checksum_rust());
+    assert_eq!(
+        unsafe { ((*UPCALLS).get_abi_structs_checksum_c)() },
+        crate::util::get_abi_structs_checksum_rust()
+    );
 
     {
         let mut builder = BUILDER.lock().unwrap();
@@ -128,8 +131,14 @@ pub extern "C" fn mmtk_bind_mutator(tls: VMMutatorThread, tid: usize) -> *mut Mu
 }
 
 #[no_mangle]
-pub extern "C" fn mmtk_post_bind_mutator(mutator: *mut Mutator<JuliaVM>, original_box_mutator: *mut Mutator<JuliaVM>) {
-    MUTATORS.write().unwrap().insert(Address::from_mut_ptr(mutator));
+pub extern "C" fn mmtk_post_bind_mutator(
+    mutator: *mut Mutator<JuliaVM>,
+    original_box_mutator: *mut Mutator<JuliaVM>,
+) {
+    MUTATORS
+        .write()
+        .unwrap()
+        .insert(Address::from_mut_ptr(mutator));
     // remove the boxed mutator
     let _ = unsafe { Box::from_raw(original_box_mutator) };
 }
@@ -137,7 +146,10 @@ pub extern "C" fn mmtk_post_bind_mutator(mutator: *mut Mutator<JuliaVM>, origina
 #[no_mangle]
 pub extern "C" fn mmtk_destroy_mutator(mutator: *mut Mutator<JuliaVM>) {
     memory_manager::destroy_mutator(unsafe { &mut *mutator });
-    MUTATORS.write().unwrap().remove(&Address::from_mut_ptr(mutator));
+    MUTATORS
+        .write()
+        .unwrap()
+        .remove(&Address::from_mut_ptr(mutator));
 }
 
 #[no_mangle]

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -157,6 +157,7 @@ pub struct Julia_Upcalls {
     pub exit_from_safepoint: extern "C" fn(old_state: i8),
     pub jl_hrtime: extern "C" fn() -> u64,
     pub update_gc_time: extern "C" fn(u64),
+    pub get_abi_structs_checksum_c: extern "C" fn() -> usize,
 }
 
 pub static mut UPCALLS: *const Julia_Upcalls = null_mut();

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -91,8 +91,6 @@ pub static DISABLED_GC: AtomicBool = AtomicBool::new(false);
 pub static USER_TRIGGERED_GC: AtomicBool = AtomicBool::new(false);
 
 lazy_static! {
-    pub static ref ARE_MUTATORS_BLOCKED: RwLock<HashMap<usize, AtomicBool>> =
-        RwLock::new(HashMap::new());
     pub static ref STW_COND: Arc<(Mutex<usize>, Condvar)> =
         Arc::new((Mutex::new(0), Condvar::new()));
     pub static ref STOP_MUTATORS: Arc<(Mutex<usize>, Condvar)> =
@@ -101,8 +99,9 @@ lazy_static! {
     pub static ref ROOT_EDGES: Mutex<HashSet<Address>> = Mutex::new(HashSet::new());
     pub static ref FINALIZER_ROOTS: RwLock<HashSet<JuliaFinalizableObject>> =
         RwLock::new(HashSet::new());
-    pub static ref MUTATOR_TLS: RwLock<HashSet<String>> = RwLock::new(HashSet::new());
-    pub static ref MUTATORS: RwLock<Vec<ObjectReference>> = RwLock::new(vec![]);
+
+    // This stores all the &'static Mutators. Use Address as &Mutator cannot be shared.
+    pub static ref MUTATORS: RwLock<HashSet<Address>> = RwLock::new(HashSet::new());
 }
 
 #[link(name = "runtime_gc_c")]

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -15,7 +15,7 @@ use mmtk::Mutator;
 use mmtk::MMTK;
 use reference_glue::JuliaFinalizableObject;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
@@ -100,7 +100,7 @@ lazy_static! {
     pub static ref FINALIZER_ROOTS: RwLock<HashSet<JuliaFinalizableObject>> =
         RwLock::new(HashSet::new());
 
-    // This stores all the &'static Mutators. Use Address as &Mutator cannot be shared.
+    // This stores *mut Mutator for all the mutators. Use Address as pointers cannot be shared across threads.
     pub static ref MUTATORS: RwLock<HashSet<Address>> = RwLock::new(HashSet::new());
 }
 

--- a/mmtk/src/util.rs
+++ b/mmtk/src/util.rs
@@ -34,3 +34,8 @@ impl RootLabel {
         }
     }
 }
+
+pub(crate) fn get_abi_structs_checksum_rust() -> usize {
+    use std::mem;
+    return mem::size_of::<mmtk::Mutator<crate::JuliaVM>>();
+}


### PR DESCRIPTION
This PR updates the bindings to work with https://github.com/mmtk/julia/pull/16.
* Update the layout of `MMTkMutatorContext`
* Do not include `gc.h` in `mmtk.h`
* Properly maintain the `MUTATORS` table. Add `mmtk_post_bind_mutator`