### PR TITLE
Simplify process_edge

### DIFF
--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -317,25 +317,8 @@ fn read_stack(addr: Address, offset: usize, lb: usize, ub: usize) -> Address {
 
 #[inline(always)]
 pub fn process_edge(closure: &mut dyn EdgeVisitor<JuliaVMEdge>, slot: Address) {
-    let internal_obj: ObjectReference = unsafe { slot.load() };
-    let internal_obj_addr = internal_obj.to_raw_address();
-    if internal_obj_addr.is_zero() {
-        return;
-    }
-
     let simple_edge = SimpleEdge::from_address(slot);
-
-    if mmtk_object_is_managed_by_mmtk(internal_obj_addr.as_usize()) {
-        closure.visit_edge(JuliaVMEdge::Simple(simple_edge));
-    } else {
-        unsafe {
-            let has_been_scanned = ((*UPCALLS).julia_object_has_been_scanned)(internal_obj_addr);
-            if has_been_scanned == 0 {
-                ((*UPCALLS).mark_julia_object_as_scanned)(internal_obj_addr);
-                closure.visit_edge(JuliaVMEdge::Simple(simple_edge));
-            }
-        }
-    }
+    closure.visit_edge(JuliaVMEdge::Simple(simple_edge));
 }
 
 #[inline(always)]
@@ -344,25 +327,8 @@ pub fn process_offset_edge(
     slot: Address,
     offset: usize,
 ) {
-    let internal_obj: ObjectReference = unsafe { slot.load() };
-    let internal_obj_addr = internal_obj.to_raw_address();
-    if internal_obj_addr.is_zero() {
-        return;
-    }
-
     let offset_edge = OffsetEdge::new_with_offset(slot, offset);
-
-    if mmtk_object_is_managed_by_mmtk(internal_obj_addr.as_usize()) {
-        closure.visit_edge(JuliaVMEdge::Offset(offset_edge));
-    } else {
-        unsafe {
-            let has_been_scanned = ((*UPCALLS).julia_object_has_been_scanned)(internal_obj_addr);
-            if has_been_scanned == 0 {
-                ((*UPCALLS).mark_julia_object_as_scanned)(internal_obj_addr);
-                closure.visit_edge(JuliaVMEdge::Offset(offset_edge));
-            }
-        }
-    }
+    closure.visit_edge(JuliaVMEdge::Offset(offset_edge));
 }
 
 #[inline(always)]


### PR DESCRIPTION
As all the objects are managed by MMTk, we do not need to check if objects are managed by MMTk.