### PR TITLE
Use SimpleEdge

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -545,7 +545,6 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=f1a0bb7fbec97dd84e35a40e8be01cf5018f2f9e#f1a0bb7fbec97dd84e35a40e8be01cf5018f2f9e"
 dependencies = [
  "atomic 0.5.1",
  "atomic-traits",
@@ -590,7 +589,6 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=f1a0bb7fbec97dd84e35a40e8be01cf5018f2f9e#f1a0bb7fbec97dd84e35a40e8be01cf5018f2f9e"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "f1a0bb7fbec97dd84e35a40e8be01cf5018f2f9e" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "28bde92892d699cea0e1e179931d3aeeee25e982" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] }

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -18,6 +18,7 @@ typedef void* MMTk_Mutator;
 typedef void* MMTk_TraceLocal;
 typedef void (*ProcessEdgeFn)(closure_pointer closure, void* slot);
 typedef void (*ProcessOffsetEdgeFn)(closure_pointer closure, void* slot, int offset);
+typedef void* (*TraceObjectImmediatelyFn)(closure_pointer closure, void* object);
 
 /**
  * Allocation
@@ -77,7 +78,7 @@ extern const void* MMTK_SIDE_LOG_BIT_BASE_ADDRESS;
 // * int is 4 bytes
 // * size_t is 8 bytes
 typedef struct {
-    void (* scan_julia_obj) (void* obj, closure_pointer closure, ProcessEdgeFn process_edge, ProcessOffsetEdgeFn process_offset_edge);
+    void (* scan_julia_obj) (void* obj, closure_pointer closure, ProcessEdgeFn process_edge, TraceObjectImmediatelyFn trace_object_immediately);
     void (* scan_julia_exc_obj) (void* obj, closure_pointer closure, ProcessEdgeFn process_edge);
     void* (* get_stackbase) (int16_t tid);
     void (* calculate_roots) (void* tls);

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -545,9 +545,7 @@ pub extern "C" fn mmtk_object_reference_write_post(
     memory_manager::object_reference_write_post(
         mutator,
         src,
-        crate::edges::JuliaVMEdge::Simple(mmtk::vm::edge_shape::SimpleEdge::from_address(
-            Address::ZERO,
-        )),
+        mmtk::vm::edge_shape::SimpleEdge::from_address(Address::ZERO),
         target,
     )
 }
@@ -561,9 +559,7 @@ pub extern "C" fn mmtk_object_reference_write_slow(
     use mmtk::MutatorContext;
     mutator.barrier().object_reference_write_slow(
         src,
-        crate::edges::JuliaVMEdge::Simple(mmtk::vm::edge_shape::SimpleEdge::from_address(
-            Address::ZERO,
-        )),
+        mmtk::vm::edge_shape::SimpleEdge::from_address(Address::ZERO),
         target,
     );
 }

--- a/mmtk/src/edges.rs
+++ b/mmtk/src/edges.rs
@@ -4,76 +4,10 @@ use mmtk::{
     vm::edge_shape::{Edge, SimpleEdge},
 };
 
-/// If a VM supports multiple kinds of edges, we can use tagged union to represent all of them.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum JuliaVMEdge {
-    Simple(SimpleEdge),
-    Offset(OffsetEdge),
-}
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
-unsafe impl Send for JuliaVMEdge {}
-
-impl Edge for JuliaVMEdge {
-    fn load(&self) -> ObjectReference {
-        match self {
-            JuliaVMEdge::Simple(e) => e.load(),
-            JuliaVMEdge::Offset(e) => e.load(),
-        }
-    }
-
-    fn store(&self, object: ObjectReference) {
-        match self {
-            JuliaVMEdge::Simple(e) => e.store(object),
-            JuliaVMEdge::Offset(e) => e.store(object),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct OffsetEdge {
-    slot_addr: *mut Atomic<Address>,
-    offset: usize,
-}
-
-unsafe impl Send for OffsetEdge {}
-
-impl OffsetEdge {
-    pub fn new_no_offset(address: Address) -> Self {
-        Self {
-            slot_addr: address.to_mut_ptr(),
-            offset: 0,
-        }
-    }
-
-    pub fn new_with_offset(address: Address, offset: usize) -> Self {
-        Self {
-            slot_addr: address.to_mut_ptr(),
-            offset,
-        }
-    }
-
-    pub fn slot_address(&self) -> Address {
-        Address::from_mut_ptr(self.slot_addr)
-    }
-
-    pub fn offset(&self) -> usize {
-        self.offset
-    }
-}
-
-impl Edge for OffsetEdge {
-    fn load(&self) -> ObjectReference {
-        let middle = unsafe { (*self.slot_addr).load(atomic::Ordering::Relaxed) };
-        let begin = middle - self.offset;
-        ObjectReference::from_raw_address(begin)
-    }
-
-    fn store(&self, object: ObjectReference) {
-        let begin = object.to_raw_address();
-        let middle = begin + self.offset;
-        unsafe { (*self.slot_addr).store(middle, atomic::Ordering::Relaxed) }
-    }
-}
+pub type JuliaVMEdge = SimpleEdge;
 
 #[derive(Hash, Clone, PartialEq, Eq, Debug)]
 pub struct JuliaMemorySlice {
@@ -157,7 +91,7 @@ impl Iterator for JuliaMemorySliceEdgeIterator {
         } else {
             let edge = self.cursor;
             self.cursor = self.cursor.shift::<ObjectReference>(1);
-            Some(JuliaVMEdge::Simple(SimpleEdge::from_address(edge)))
+            Some(mmtk::vm::edge_shape::SimpleEdge::from_address(edge))
         }
     }
 }

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -125,13 +125,16 @@ type ProcessEdgeFn =
 type ProcessOffsetEdgeFn =
     *const extern "C" fn(closure: &mut dyn EdgeVisitor<JuliaVMEdge>, slot: Address, offset: usize);
 
+type TraceObjectImmediatelyFn =
+    *const extern "C" fn(closure: &mut dyn EdgeVisitor<JuliaVMEdge>, object: ObjectReference) -> ObjectReference;
+
 #[repr(C)]
 pub struct Julia_Upcalls {
     pub scan_julia_obj: extern "C" fn(
         obj: Address,
         closure: &mut dyn EdgeVisitor<JuliaVMEdge>,
         process_edge: ProcessEdgeFn,
-        process_offset_edge: ProcessOffsetEdgeFn,
+        trace_object_immediately: TraceObjectImmediatelyFn,
     ),
     pub scan_julia_exc_obj: extern "C" fn(
         obj: Address,

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -1,8 +1,10 @@
 use crate::edges::JuliaVMEdge;
 #[cfg(feature = "scan_obj_c")]
 use crate::julia_scanning::process_edge;
+// #[cfg(feature = "scan_obj_c")]
+// use crate::julia_scanning::process_offset_edge;
 #[cfg(feature = "scan_obj_c")]
-use crate::julia_scanning::process_offset_edge;
+use crate::julia_scanning::trace_object_immediately;
 use crate::FINALIZER_ROOTS;
 use crate::{ROOT_EDGES, ROOT_NODES, SINGLETON, UPCALLS};
 use mmtk::memory_manager;
@@ -69,7 +71,7 @@ impl Scanning<JuliaVM> for VMScanning {
             .lock()
             .unwrap()
             .drain()
-            .map(|e| JuliaVMEdge::Simple(mmtk::vm::edge_shape::SimpleEdge::from_address(e)))
+            .map(|e| mmtk::vm::edge_shape::SimpleEdge::from_address(e))
             .collect();
         info!("{} thread root edges", roots.len());
         factory.create_process_edge_roots_work(roots);
@@ -106,7 +108,7 @@ pub fn process_object(object: ObjectReference, closure: &mut dyn EdgeVisitor<Jul
     #[cfg(feature = "scan_obj_c")]
     {
         unsafe {
-            ((*UPCALLS).scan_julia_obj)(addr, closure, process_edge as _, process_offset_edge as _)
+            ((*UPCALLS).scan_julia_obj)(addr, closure, process_edge as _, trace_object_immediately as _)
         };
     }
 


### PR DESCRIPTION
This PR is based on https://github.com/mmtk/mmtk-core/pull/865. It relies on the new method `trace_object_immediately` introduced in the PR to deal with internal references after removing `OffsetEdge`.