### PR TITLE
Update ci-test.sh

### DIFF
--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -8,7 +8,7 @@ cur=$(realpath $(dirname "$0"))
 
 # Build release
 cd $cur
-./ci-build.sh release immix
+./ci-build.sh release Immix
 
 # Use release build to run tests
 cd $cur


### PR DESCRIPTION
This PR updates `ci-test.sh` which is used by MMTk core to test the binding. We have done the change for the CI script for the `mmtk-julia` repo in https://github.com/mmtk/mmtk-julia/pull/79, but I forgot to update `ci-test.sh`.