### PR TITLE
Making sure worker_tls is different than the mutator tls

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "libc",
  "log",
  "mmtk",
+ "thread-id",
 ]
 
 [[package]]
@@ -652,6 +653,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -863,6 +873,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.27",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee93aa2b8331c0fec9091548843f2c90019571814057da3b783f9de09349d73"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi",
 ]
 
 [[package]]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -38,6 +38,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 enum-map = ">=2.1"
 atomic = "0.4.6"
 chrono = "*"
+thread-id = "*"
 
 # ykstackmaps = { git = "https://github.com/udesou/ykstackmaps.git", branch = "udesou-master", version = "*" }
 

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -60,8 +60,6 @@ impl Collection<JuliaVM> for VMCollection {
             crate::api::mmtk_total_bytes()
         );
 
-        // std::fs::remove_file("/home/eduardo/mmtk-julia/scanned_objs.log").expect("File delete failed");
-        // std::fs::remove_file("/home/eduardo/mmtk-julia/copied_objs.log").expect("File delete failed");
         trace!("Resuming mutators.");
     }
 


### PR DESCRIPTION
Fixes an issue that allocating space for copying objects could cause a deadlock.