### PR TITLE
Fixing mismatch between C and Rust version of Julia functions

### DIFF
--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -552,14 +552,14 @@ const JL_BT_NON_PTR_ENTRY: usize = usize::MAX;
 
 pub fn mmtk_jl_bt_is_native(bt_entry: *mut mmtk_jl_bt_element_t) -> bool {
     let entry = unsafe { (*bt_entry).__bindgen_anon_1.uintptr };
-    entry == JL_BT_NON_PTR_ENTRY
+    entry != JL_BT_NON_PTR_ENTRY
 }
 
 pub fn mmtk_jl_bt_entry_size(bt_entry: *mut mmtk_jl_bt_element_t) -> usize {
     if mmtk_jl_bt_is_native(bt_entry) {
         1
     } else {
-        2 + mmtk_jl_bt_num_jlvals(bt_entry) + mmtk_jl_bt_num_jlvals(bt_entry)
+        2 + mmtk_jl_bt_num_jlvals(bt_entry) + mmtk_jl_bt_num_uintvals(bt_entry)
     }
 }
 


### PR DESCRIPTION
The functions `mmtk_jl_bt_entry_size` and `mmtk_jl_bt_is_native` were slightly different than their C counterparts ([jl_bt_entry_size](https://github.com/mmtk/julia/blob/5733c287d803316e6da1771db35e49c767804112/src/julia_internal.h#L1139C22-L1139C38) and [jl_bt_is_native](https://github.com/mmtk/julia/blob/5733c287d803316e6da1771db35e49c767804112/src/julia_internal.h#L1095)). This PR fixes the differences from both implementations which could lead to providing incorrect roots to MMTk.