### PR TITLE
Adding support for allocating in a non-moving space

### DIFF
--- a/julia/mmtk_julia.c
+++ b/julia/mmtk_julia.c
@@ -96,6 +96,34 @@ JL_DLLEXPORT jl_value_t *jl_mmtk_gc_alloc_big(jl_ptls_t ptls, size_t sz)
     return result;
 }
 
+// allocating in a non-moving space
+JL_DLLEXPORT jl_value_t *jl_mmtk_gc_alloc_non_moving(jl_ptls_t ptls,
+                                                    int osize, void *ty)
+{
+    // safepoint
+    jl_gc_safepoint_(ptls);
+
+    jl_value_t *v;
+    if ((uintptr_t)ty != jl_buff_tag) {
+        // v needs to be 16 byte aligned, therefore v_tagged needs to be offset accordingly to consider the size of header
+        jl_taggedvalue_t *v_tagged = (jl_taggedvalue_t *)mmtk_alloc(&ptls->mmtk_mutator, osize, 16, sizeof(jl_taggedvalue_t), 6);
+        v = jl_valueof(v_tagged);
+        mmtk_non_moving_post_alloc_fast(&ptls->mmtk_mutator, v, osize);
+    } else {
+        // allocating an extra word to store the size of buffer objects
+        jl_taggedvalue_t *v_tagged = (jl_taggedvalue_t *)mmtk_alloc(&ptls->mmtk_mutator, osize+sizeof(jl_taggedvalue_t), 16, 0, 6);
+        jl_value_t* v_tagged_aligned = ((jl_value_t*)((char*)(v_tagged) + sizeof(jl_taggedvalue_t)));
+        v = jl_valueof(v_tagged_aligned);
+        mmtk_store_obj_size_c(v, osize + sizeof(jl_taggedvalue_t));
+        mmtk_non_moving_post_alloc_fast(&ptls->mmtk_mutator, v, osize + sizeof(jl_taggedvalue_t));
+    }
+
+    ptls->gc_num.allocd += osize;
+    ptls->gc_num.poolalloc++;
+
+    return v;
+}
+
 static void mmtk_sweep_malloced_arrays(void) JL_NOTSAFEPOINT
 {
     void* iter = new_mutator_iterator();


### PR DESCRIPTION
Adding the API on the binding side to support allocating object into a non-moving space.