### PR TITLE
Splitting LinearAlgebra tests 

### DIFF
--- a/.github/scripts/ci-test-LinearAlgebra.sh
+++ b/.github/scripts/ci-test-LinearAlgebra.sh
@@ -1,0 +1,9 @@
+# Running LinearAlgebra as a separate item
+# Given it takes on average more than 2.5h to run 
+
+set -e
+
+. $(dirname "$0")/common.sh
+
+echo "-> Run single threaded"
+ci_run_jl_test "LinearAlgebra" 1

--- a/.github/scripts/ci-test-stdlib.sh
+++ b/.github/scripts/ci-test-stdlib.sh
@@ -20,6 +20,8 @@ declare -a tests_to_skip=(
     # FIXME: We should run this test when the above issue is resolved.
     "Pkg",
     "SparseArrays"
+    # Running LinearAlgebra in a separate job
+    "LinearAlgebra"
 )
 # These tests need multiple workers.
 declare -a tests_with_multi_workers=(

--- a/.github/scripts/ci-test-stdlib.sh
+++ b/.github/scripts/ci-test-stdlib.sh
@@ -28,7 +28,6 @@ declare -a tests_with_multi_workers=(
 # These tests run with a single worker
 declare -a tests_with_single_worker=(
     "SparseArrays",
-    "LinearAlgebra"
 )
 
 stdlib_path=$JULIA_PATH/usr/share/julia/stdlib

--- a/.github/workflows/binding-tests.yml
+++ b/.github/workflows/binding-tests.yml
@@ -57,3 +57,19 @@ jobs:
       - name: Test Julia
         run: |
           ./.github/scripts/ci-test-stdlib.sh
+
+  build-test-LinearAlgebra:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup environments
+        run: |
+          ./.github/scripts/ci-checkout.sh
+          ./.github/scripts/ci-setup.sh
+      - name: Build Julia (Release)
+        run: |
+          ./.github/scripts/ci-build.sh release ${{ inputs.gc_plan }}
+      - name: Test Julia
+        run: |
+          ./.github/scripts/ci-test-LinearAlgebra.sh


### PR DESCRIPTION
With `FORCE_ASSERTIONS=1` and `LLVM_ASSERTIONS=1`, the CI is often timing out as `test-stdlib` is taking longer than 6h. This PR splits the LinearAlgebra tests, making them run separately, hopefully avoiding `test-stdlib` to timeout. 