### PR TITLE
Run CI and mergify for v1.9.2+RAI

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,23 @@
 pull_request_rules:
-  - name: backport patches to v1.8.2-RAI
+  - name: backport patches to v1.8.2+RAI
     conditions:
       - base=master
-      - label=backport-v1.8.2-RAI
+      - label=backport-v1.8.2+RAI
     actions:
       backport:
         branches:
-          - v1.8.2-RAI
+          - v1.8.2+RAI
+        assignees:
+          - "{{ author }}"
+        label_conflicts: backport-conflicts
+  - name: backport patches to v1.9.2+RAI
+    conditions:
+      - base=master
+      - label=backport-v1.9.2+RAI
+    actions:
+      backport:
+        branches:
+          - v1.9.2+RAI
         assignees:
           - "{{ author }}"
         label_conflicts: backport-conflicts

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -10,8 +10,9 @@ export MMTK_JULIA_DIR=$BINDING_PATH
 # Make sure we have enough heap to build Julia
 export MMTK_MIN_HSIZE_G=0.5
 export MMTK_MAX_HSIZE_G=4
-# Make sure we do not get OOM killed. The Github runner has ~7G RAM.
-export JULIA_TEST_MAXRSS_MB=6500
+# Make sure we do not get OOM killed.
+total_mem=$(free -m | awk '/^Mem:/ {print $2}')
+export JULIA_TEST_MAXRSS_MB=$total_mem
 
 ci_run_jl_test() {
     test=$1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches:
       - master
-      - v1.8.2-RAI
+      - v1.8.2+RAI
+      - v1.9.2+RAI
 
 concurrency:
   # Cancels pending runs when a PR gets updated.


### PR DESCRIPTION
This PR allows CI and mergify to work with `v1.9.2+RAI` and `v1.8.2+RAI` (renamed from `v1.8.2-RAI`). It also changes the CI script to set the test max RSS based on the system memory (it seems Github hosted runners had an upgrade, and they now have 16G memory instead of 7G).