### PR TITLE
Escape + in the branch name for the workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches:
       - master
-      - v1.8.2+RAI
-      - v1.9.2+RAI
+      - v1.8.2\+RAI
+      - v1.9.2\+RAI
 
 concurrency:
   # Cancels pending runs when a PR gets updated.


### PR DESCRIPTION
According to https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore, `+` that appears in the branch name needs to be escaped.