### PR TITLE
Fixing sticky immix

### DIFF
--- a/.github/scripts/ci-test-stdlib.sh
+++ b/.github/scripts/ci-test-stdlib.sh
@@ -22,6 +22,8 @@ declare -a tests_to_skip=(
     "SparseArrays"
     # Running LinearAlgebra in a separate job
     "LinearAlgebra"
+    # This is failing for v1.9.2 on the stock Julia as well.
+    "Profile"
 )
 # These tests need multiple workers.
 declare -a tests_with_multi_workers=(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches:
       - master
-      - v1.8.2+RAI
-      - v1.9.2+RAI
+      - v1.8.2\+RAI
+      - v1.9.2\+RAI
 
 concurrency:
   # Cancels pending runs when a PR gets updated.

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "8c31b9a7da071a370848ea693c69a95b4a80c998"
+julia_repo = "https://github.com/mmtk/julia.git"
+julia_version = "dc7b07e74c2563f3eb3363675e0e3eb87c0044ce"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "b3ce6db9f886f15c53debec22e55761da909f9e0"
+julia_version = "1c3c669c6df2249a29d2f5835c4ee80491b76b43"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "1c3c669c6df2249a29d2f5835c4ee80491b76b43"
+julia_repo = "https://github.com/mmtk/julia.git"
+julia_version = "f15694cd3f55945ed0e4880445eda42edc7b956b"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "5c406d9bb20d76e2298a6101f171cfac491f651c"
+julia_repo = "https://github.com/udesou/julia.git"
+julia_version = "b3ce6db9f886f15c53debec22e55761da909f9e0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "f15694cd3f55945ed0e4880445eda42edc7b956b"
+julia_repo = "https://github.com/udesou/julia.git"
+julia_version = "8c31b9a7da071a370848ea693c69a95b4a80c998"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -44,10 +44,12 @@ pub unsafe fn scan_julia_object<EV: EdgeVisitor<JuliaVMEdge>>(obj: Address, clos
     let vt = mmtk_jl_typeof(obj);
 
     if vt as usize == JULIA_BUFF_TAG {
-        let as_tagged_value = obj.as_usize() - std::mem::size_of::<crate::julia_scanning::mmtk_jl_taggedvalue_t>();
+        let as_tagged_value =
+            obj.as_usize() - std::mem::size_of::<crate::julia_scanning::mmtk_jl_taggedvalue_t>();
         let t_header = Address::from_usize(as_tagged_value).load::<Address>();
         let tag = t_header.as_usize() & 3;
-        if tag == 2 { // buf is binding
+        if tag == 2 {
+            // buf is binding
             let b = obj.to_ptr::<mmtk_jl_binding_t>();
             let value = ::std::ptr::addr_of!((*b).value);
             let globalref = ::std::ptr::addr_of!((*b).globalref);

--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -43,7 +43,26 @@ pub unsafe fn scan_julia_object<EV: EdgeVisitor<JuliaVMEdge>>(obj: Address, clos
     // get Julia object type
     let vt = mmtk_jl_typeof(obj);
 
-    if vt == jl_symbol_type || vt as usize == JULIA_BUFF_TAG {
+    if vt as usize == JULIA_BUFF_TAG {
+        let as_tagged_value = obj.as_usize() - std::mem::size_of::<crate::julia_scanning::mmtk_jl_taggedvalue_t>();
+        let t_header = Address::from_usize(as_tagged_value).load::<Address>();
+        let tag = t_header.as_usize() & 3;
+        if tag == 2 { // buf is binding
+            let b = obj.to_ptr::<mmtk_jl_binding_t>();
+            let value = ::std::ptr::addr_of!((*b).value);
+            let globalref = ::std::ptr::addr_of!((*b).globalref);
+            let ty = ::std::ptr::addr_of!((*b).ty);
+
+            process_edge(closure, Address::from_usize(value as usize));
+            process_edge(closure, Address::from_usize(globalref as usize));
+            process_edge(closure, Address::from_usize(ty as usize));
+            return;
+        } else {
+            return; // do not scan buffers
+        }
+    }
+
+    if vt == jl_symbol_type {
         return;
     }
 

--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -43,8 +43,8 @@ pub unsafe fn scan_julia_object<EV: EdgeVisitor<JuliaVMEdge>>(obj: Address, clos
     // get Julia object type
     let vt = mmtk_jl_typeof(obj);
 
-    // We don't scan buffers, as they will be scanned as a part of its parent object. 
-    // But when a jl_binding_t buffer is inserted into remset, they have be to scanned. 
+    // We don't scan buffers, as they will be scanned as a part of its parent object.
+    // But when a jl_binding_t buffer is inserted into remset, they have be to scanned.
     // The gc bits (tag), which is set in the write barrier, tells us if the buffer is in the remset.
     // FIXME: set the tags back to 0?
     if vt as usize == JULIA_BUFF_TAG {

--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -43,6 +43,10 @@ pub unsafe fn scan_julia_object<EV: EdgeVisitor<JuliaVMEdge>>(obj: Address, clos
     // get Julia object type
     let vt = mmtk_jl_typeof(obj);
 
+    // We don't scan buffers, as they will be scanned as a part of its parent object. 
+    // But when a jl_binding_t buffer is inserted into remset, they have be to scanned. 
+    // The gc bits (tag), which is set in the write barrier, tells us if the buffer is in the remset.
+    // FIXME: set the tags back to 0?
     if vt as usize == JULIA_BUFF_TAG {
         let as_tagged_value =
             obj.as_usize() - std::mem::size_of::<crate::julia_scanning::mmtk_jl_taggedvalue_t>();


### PR DESCRIPTION
This PR should be merged with https://github.com/mmtk/julia/pull/32. 

Copying the description here for simplicity:

> At least one of the issues with sticky immix back ported to [v1.9.2+RAI](https://github.com/mmtk/mmtk-julia/tree/v1.9.2%2BRAI) is that bindings [may occur in the remset](https://github.com/mmtk/julia/blob/c01026c91a3e2e6a064e75e0d4d4cc2f8c0d4c77/src/gc.c#L2417-L2433). However, bindings are currently skipped when scanned by MMTk since they are allocated as buffers. Therefore, we need a way to specify which bindings should actually be scanned since they were added via write barrier.
> 
> Possible sources of problems that haven't been verified yet:
> (i) can the `bits.gc` value change after being set by the write barrier?
> (ii) should we reset the value after the object has been scanned?

This PR adds code for scanning buffers that are Julia bindings that were added in the write barrier.