### PR TITLE
Push pinning roots

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -10,6 +10,8 @@ export MMTK_JULIA_DIR=$BINDING_PATH
 # Make sure we have enough heap to build Julia
 export MMTK_MIN_HSIZE_G=0.5
 export MMTK_MAX_HSIZE_G=4
+# Print out a backtrace in case of an error
+export RUST_BACKTRACE=1
 # Make sure we do not get OOM killed.
 total_mem=$(free -m | awk '/^Mem:/ {print $2}')
 export JULIA_TEST_MAXRSS_MB=$total_mem

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "09e025b25c65e5842b6eeeb3c81ba4cab97f5192"
+julia_repo = "https://github.com/udesou/julia.git"
+julia_version = "94d63722a0ea3f1381ec400bae50f27ec76e8c32"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "7d89137e498824deed21d0f071976a4abc2ae0fa"
+julia_version = "0ac54e680f9a8b57bb1fd8ef04919ce9898ae77b"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "94d63722a0ea3f1381ec400bae50f27ec76e8c32"
+julia_version = "5f2b75e93742646cd74ff502624652e56336e2da"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "5f2b75e93742646cd74ff502624652e56336e2da"
+julia_repo = "https://github.com/mmtk/julia.git"
+julia_version = "7d89137e498824deed21d0f071976a4abc2ae0fa"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -385,7 +385,7 @@ pub unsafe fn mmtk_scan_gcstack<EV: EdgeVisitor<JuliaVMEdge>>(
         let s_nroots_addr = ::std::ptr::addr_of!((*s).nroots);
         let mut nroots = read_stack(Address::from_ptr(s_nroots_addr), offset, lb, ub);
         debug_assert!(nroots.as_usize() as u32 <= UINT32_MAX);
-        let mut nr = nroots >> 2;
+        let mut nr = nroots >> 3;
 
         loop {
             let rts = Address::from_mut_ptr(s).shift::<Address>(2);
@@ -431,7 +431,7 @@ pub unsafe fn mmtk_scan_gcstack<EV: EdgeVisitor<JuliaVMEdge>>(
             let s_nroots_addr = ::std::ptr::addr_of!((*s).nroots);
             let new_nroots = read_stack(Address::from_ptr(s_nroots_addr), offset, lb, ub);
             nroots = new_nroots;
-            nr = nroots >> 2;
+            nr = nroots >> 3;
             continue;
         }
     }

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -1,4 +1,5 @@
 use crate::edges::JuliaVMEdge;
+use crate::julia_scanning::process_offset_edge;
 use crate::julia_scanning::{get_stack_addr, process_edge, read_stack};
 use crate::julia_types::{mmtk_jl_gcframe_t, mmtk_jl_task_t, UINT32_MAX};
 use crate::{SINGLETON, UPCALLS};
@@ -209,12 +210,6 @@ pub unsafe fn mmtk_scan_gcstack_roots<EV: EdgeVisitor<JuliaVMEdge>>(
 ) {
     let stkbuf = (*ta).stkbuf;
     let copy_stack = (*ta).copy_stack_custom();
-
-    #[cfg(feature = "julia_copy_stack")]
-    if stkbuf != std::ptr::null_mut() && copy_stack != 0 {
-        let stkbuf_edge = Address::from_ptr(::std::ptr::addr_of!((*ta).stkbuf));
-        process_edge(closure, stkbuf_edge);
-    }
 
     let mut s = (*ta).gcstack;
     let (mut offset, mut lb, mut ub) = (0 as isize, 0 as u64, u64::MAX);


### PR DESCRIPTION
Supporting processing roots in the shadow stack that are not transitively pinned (only the root object is pinned), and therefore should enable moving more objects. 

NB: Should be merged with https://github.com/mmtk/julia/pull/43.