### PR TITLE
Julia's stock GC trigger heuristics

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "0ac54e680f9a8b57bb1fd8ef04919ce9898ae77b"
+julia_repo = "https://github.com/udesou/julia.git"
+julia_version = "c9150ccb6347bfd535ce7d391ea141a40b0dad70"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "2a68c3905dfda3e8556fb37f4c11effbf30feac6"
+julia_version = "84224df9b3a7770c2f37b74e64bc326f979a5adf"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "c9150ccb6347bfd535ce7d391ea141a40b0dad70"
+julia_version = "2a68c3905dfda3e8556fb37f4c11effbf30feac6"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "84224df9b3a7770c2f37b74e64bc326f979a5adf"
+julia_repo = "https://github.com/mmtk/julia.git"
+julia_version = "5bb4714e34084ae851d2b6ecb2c1da0242c912c0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -276,9 +276,9 @@ pub extern "C" fn mmtk_handle_user_collection_request(tls: VMMutatorThread, coll
         // auto
         0 => memory_manager::handle_user_collection_request::<JuliaVM>(&SINGLETON, tls),
         // full
-        1 => SINGLETON.handle_user_collection_request(tls, true, true),
+        1 => SINGLETON.handle_user_collection_request(tls, false, true),
         // incremental
-        2 => SINGLETON.handle_user_collection_request(tls, true, false),
+        2 => SINGLETON.handle_user_collection_request(tls, false, false),
         _ => unreachable!(),
     }
 }

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -68,7 +68,12 @@ pub extern "C" fn mmtk_gc_init(
             // If MMTK_GC_TRIGGER is not set, then use the min/max heap size from the arguments.
             Err(_) => {
                 let success;
-                if min_heap_size != 0 {
+                if min_heap_size == 0 && max_heap_size == 0 {
+                    success = builder
+                        .options
+                        .gc_trigger
+                        .set(mmtk::util::options::GCTriggerSelector::Delegated);
+                } else if min_heap_size != 0 {
                     info!(
                         "Setting mmtk heap size to a variable size with min-max of {}-{} (in bytes)",
                         min_heap_size, max_heap_size

--- a/mmtk/src/gc_trigger.rs
+++ b/mmtk/src/gc_trigger.rs
@@ -39,7 +39,9 @@ pub struct JuliaGCTrigger {
     interval_all_threads: AtomicUsize,
     actual_allocd: AtomicUsize,
     prev_sweep_full: AtomicBool,
-
+    /// The number of pending allocation pages. The allocation requests for them have failed, and a GC is triggered.
+    /// We will need to take them into consideration so that the new heap size can accomodate those allocations.
+    pending_pages: AtomicUsize,
     last_recorded_reserved_pages: AtomicUsize,
 }
 
@@ -79,6 +81,7 @@ impl JuliaGCTrigger {
             actual_allocd: AtomicUsize::new(0),
             prev_sweep_full: AtomicBool::new(true),
             last_recorded_reserved_pages: AtomicUsize::new(0),
+            pending_pages: AtomicUsize::new(0),
         }
     }
 }
@@ -86,7 +89,10 @@ impl JuliaGCTrigger {
 impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
     fn on_gc_start(&self, mmtk: &'static MMTK<JuliaVM>) {
         let reserved_pages_in_last_gc = self.last_recorded_reserved_pages.load(Ordering::Relaxed);
-        let reserved_pages_now = mmtk.get_plan().get_reserved_pages();
+        // reserved pages now should include pending allocations
+        let reserved_pages_now =
+            mmtk.get_plan().get_reserved_pages() + self.pending_pages.load(Ordering::SeqCst);
+
         self.last_recorded_reserved_pages
             .store(reserved_pages_now, Ordering::Relaxed);
         self.actual_allocd.store(
@@ -103,30 +109,31 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
             },
             Ordering::Relaxed,
         );
-        trace!("On GC start: alloc'd = {} = reserved now {} pages - reserved after last gc {} pages = {} pages, prev_sweep = {}", self.actual_allocd.load(Ordering::Relaxed), reserved_pages_now, reserved_pages_in_last_gc, reserved_pages_now.saturating_sub(reserved_pages_in_last_gc), self.prev_sweep_full.load(Ordering::Relaxed));
+        info!("On GC start: alloc'd = {} = reserved now {} pages - reserved after last gc {} pages = {} pages, prev_sweep = {}", self.actual_allocd.load(Ordering::Relaxed), reserved_pages_now, reserved_pages_in_last_gc, reserved_pages_now.saturating_sub(reserved_pages_in_last_gc), self.prev_sweep_full.load(Ordering::Relaxed));
     }
     fn on_gc_end(&self, mmtk: &'static MMTK<JuliaVM>) {
         use crate::mmtk::vm::ActivePlan;
         let n_mutators = crate::active_plan::VMActivePlan::number_of_mutators();
 
         let reserved_pages_before_gc = self.last_recorded_reserved_pages.load(Ordering::Relaxed);
-        let reserved_pages_now = mmtk.get_plan().get_reserved_pages();
+        let reserved_pages_now =
+            mmtk.get_plan().get_reserved_pages() + self.pending_pages.load(Ordering::SeqCst);
         let freed = conversions::pages_to_bytes(
             reserved_pages_before_gc.saturating_sub(reserved_pages_now),
         );
         self.last_recorded_reserved_pages
             .store(reserved_pages_now, Ordering::Relaxed);
-        trace!("On GC end: freed = {} = reserved before GC {} pages - reserved now {} pages = {} pages", freed, reserved_pages_before_gc, reserved_pages_now, reserved_pages_before_gc.saturating_sub(reserved_pages_now));
+        info!("On GC end: freed = {} = reserved before GC {} pages - reserved now {} pages = {} pages", freed, reserved_pages_before_gc, reserved_pages_now, reserved_pages_before_gc.saturating_sub(reserved_pages_now));
 
         // ported from gc.c -- before sweeping in the original code.
         // ignore large frontier (large frontier means the bytes of pointers reachable from the remset is larger than the default collect interval)
         let gc_auto = !mmtk.is_user_triggered_collection();
         let not_freed_enough = gc_auto
-            && (freed as f64) < (self.actual_allocd.load(Ordering::Relaxed) as f64 * 0.7f64);
+            && ((freed as f64) < (self.actual_allocd.load(Ordering::Relaxed) as f64 * 0.7f64));
         let mut sweep_full = false;
         if gc_auto {
             if not_freed_enough {
-                trace!(
+                info!(
                     "Not freed enough: double the interval {:?} -> {:?}",
                     self.interval.load(Ordering::Relaxed),
                     self.interval.load(Ordering::Relaxed) * 2
@@ -145,7 +152,7 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
             }
             if self.interval.load(Ordering::Relaxed) > maxmem {
                 sweep_full = true;
-                trace!(
+                info!(
                     "Force full heap. Clamp interval back to max mem ({} > {}).",
                     self.interval.load(Ordering::Relaxed),
                     maxmem
@@ -156,11 +163,11 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
 
         let live_bytes = conversions::pages_to_bytes(reserved_pages_now);
         if live_bytes > self.max_total_memory.load(Ordering::Relaxed) {
-            trace!("Force full heap. Live > max total memory");
+            info!("Force full heap. Live > max total memory");
             sweep_full = true;
         }
         if GC_ALWAYS_SWEEP_FULL {
-            trace!("Force full heap. Always");
+            info!("Force full heap. Always");
             sweep_full = true;
         }
 
@@ -178,7 +185,7 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
                 let tot =
                     2f64 * (live_bytes + self.actual_allocd.load(Ordering::Relaxed)) as f64 / 3f64;
                 let _ = self.interval.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |interval| if (interval as f64) > tot {
-                    trace!("Not freed enough. Decrease interval to 2/3 * (live + alloc'd) = {}", tot);
+                    info!("Not freed enough. Decrease interval to 2/3 * (live + alloc'd) = {}", tot);
                     Some(tot as usize)
                 } else { None });
             } else {
@@ -188,7 +195,7 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
                     self.interval
                         .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |interval| {
                             if interval > half {
-                                trace!("Decrease interval to half live bytes = {}", half);
+                                info!("Decrease interval to half live bytes = {}", half);
                                 Some(half)
                             } else {
                                 None
@@ -201,7 +208,7 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
                 .interval
                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |interval| {
                     if interval < DEFAULT_COLLECT_INTERVAL {
-                        trace!(
+                        info!(
                             "Don't let interval go below default = {}",
                             DEFAULT_COLLECT_INTERVAL
                         );
@@ -215,7 +222,7 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
         let max_total_memory = self.max_total_memory.load(Ordering::Relaxed);
         if self.interval.load(Ordering::Relaxed) + live_bytes > max_total_memory {
             if live_bytes < max_total_memory {
-                trace!(
+                info!(
                     "About to reach max total memory. Decrease interval = {}",
                     max_total_memory.saturating_sub(live_bytes)
                 );
@@ -224,7 +231,7 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
                     Ordering::Relaxed,
                 );
             } else {
-                trace!(
+                info!(
                     "Reached max total memory. Use default interval = {}",
                     DEFAULT_COLLECT_INTERVAL
                 );
@@ -240,6 +247,13 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
             self.interval.load(Ordering::Relaxed) * n_mutators / 2,
             Ordering::Relaxed,
         );
+
+        // Clear pending allocation pages at the end of GC, no matter we used it or not.
+        self.pending_pages.store(0, Ordering::SeqCst);
+    }
+
+    fn on_pending_allocation(&self, pages: usize) {
+        self.pending_pages.fetch_add(pages, Ordering::SeqCst);
     }
 
     /// Is a GC required now?
@@ -249,9 +263,19 @@ impl GCTriggerPolicy<JuliaVM> for JuliaGCTrigger {
         space: Option<SpaceStats<JuliaVM>>,
         plan: &dyn Plan<VM = JuliaVM>,
     ) -> bool {
+        let reserved_pages_now = plan.get_reserved_pages();
+        let reserved_pages_before_gc = self.last_recorded_reserved_pages.load(Ordering::Relaxed);
+
         let allocd_so_far = conversions::pages_to_bytes(
-            plan.get_reserved_pages() - self.last_recorded_reserved_pages.load(Ordering::Relaxed),
+            reserved_pages_now.saturating_sub(reserved_pages_before_gc),
         );
+
+        info!(
+            "Reserved now = {}, last recorded reserved = {}, Allocd so far: {}. interval_all_threads = {}",
+            plan.get_reserved_pages(), self.last_recorded_reserved_pages.load(Ordering::Relaxed), allocd_so_far,
+            self.interval_all_threads.load(Ordering::Relaxed)
+        );
+
         // Check against interval_all_threads, as we count allocation from all threads.
         if allocd_so_far > self.interval_all_threads.load(Ordering::Relaxed) {
             return true;


### PR DESCRIPTION
This PR fixes Julia's GC trigger option/heuristics and enables it as default (by changing the initial values to in `mmtk-gc.c`: https://github.com/mmtk/julia/pull/54).