### PR TITLE
Trace the owner field of bindings

### DIFF
--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -64,10 +64,13 @@ pub unsafe fn scan_julia_object<SV: SlotVisitor<JuliaVMSlot>>(obj: Address, clos
             let value = ::std::ptr::addr_of!((*b).value);
             let globalref = ::std::ptr::addr_of!((*b).globalref);
             let ty = ::std::ptr::addr_of!((*b).ty);
+            let owner = ::std::ptr::addr_of!((*b).owner);
 
             process_slot(closure, Address::from_usize(value as usize));
             process_slot(closure, Address::from_usize(globalref as usize));
             process_slot(closure, Address::from_usize(ty as usize));
+            process_slot(closure, Address::from_usize(owner as usize));
+
             // clearing tag bits
             Address::from_usize(as_tagged_value).store::<usize>(t_header.as_usize() & !3);
             return;
@@ -234,10 +237,12 @@ pub unsafe fn scan_julia_object<SV: SlotVisitor<JuliaVMSlot>>(obj: Address, clos
             let value = ::std::ptr::addr_of!((*b).value);
             let globalref = ::std::ptr::addr_of!((*b).globalref);
             let ty = ::std::ptr::addr_of!((*b).ty);
+            let owner = ::std::ptr::addr_of!((*b).owner);
 
             process_slot(closure, Address::from_usize(value as usize));
             process_slot(closure, Address::from_usize(globalref as usize));
             process_slot(closure, Address::from_usize(ty as usize));
+            process_slot(closure, Address::from_usize(owner as usize));
             begin = begin.shift::<Address>(2);
         }
 


### PR DESCRIPTION
The `owner` field points to the module that a binding belongs to. It was not traced. So if the module is moved, the pointer becomes invalid. The alternative is to pin or use non moving allocation for all the module objects here: https://github.com/mmtk/julia/blob/d98aa333178d372d96f3c99c712edf0018a50289/src/module.c#L15.