### PR TITLE
Skip conservative stack scanning if the current GC won't move objects

### DIFF
--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -539,7 +539,7 @@ fn assert_is_object(object: ObjectReference) {
 #[no_mangle]
 pub extern "C" fn mmtk_pin_object(object: ObjectReference) -> bool {
     assert_is_object(object);
-    crate::early_return_for_non_moving!(false);
+    crate::early_return_for_non_moving_build!(false);
 
     memory_manager::pin_object(object)
 }
@@ -547,7 +547,7 @@ pub extern "C" fn mmtk_pin_object(object: ObjectReference) -> bool {
 #[no_mangle]
 pub extern "C" fn mmtk_unpin_object(object: ObjectReference) -> bool {
     assert_is_object(object);
-    crate::early_return_for_non_moving!(false);
+    crate::early_return_for_non_moving_build!(false);
 
     memory_manager::unpin_object(object)
 }
@@ -555,14 +555,14 @@ pub extern "C" fn mmtk_unpin_object(object: ObjectReference) -> bool {
 #[no_mangle]
 pub extern "C" fn mmtk_is_object_pinned(object: ObjectReference) -> bool {
     assert_is_object(object);
-    crate::early_return_for_non_moving!(false);
+    crate::early_return_for_non_moving_build!(false);
 
     memory_manager::is_pinned(object)
 }
 
 #[no_mangle]
 pub extern "C" fn mmtk_pin_pointer(addr: Address) -> bool {
-    crate::early_return_for_non_moving!(false);
+    crate::early_return_for_non_moving_build!(false);
 
     if mmtk_object_is_managed_by_mmtk(addr.as_usize()) {
         if !crate::object_model::is_addr_in_immixspace(addr) {
@@ -600,7 +600,7 @@ pub extern "C" fn mmtk_pin_pointer(addr: Address) -> bool {
 
 #[no_mangle]
 pub extern "C" fn mmtk_unpin_pointer(addr: Address) -> bool {
-    crate::early_return_for_non_moving!(false);
+    crate::early_return_for_non_moving_build!(false);
 
     if mmtk_object_is_managed_by_mmtk(addr.as_usize()) {
         if !crate::object_model::is_addr_in_immixspace(addr) {
@@ -637,7 +637,7 @@ pub extern "C" fn mmtk_unpin_pointer(addr: Address) -> bool {
 
 #[no_mangle]
 pub extern "C" fn mmtk_is_pointer_pinned(addr: Address) -> bool {
-    crate::early_return_for_non_moving!(false);
+    crate::early_return_for_non_moving_build!(false);
 
     if mmtk_object_is_managed_by_mmtk(addr.as_usize()) {
         if !crate::object_model::is_addr_in_immixspace(addr) {

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use crate::{BLOCK_FOR_GC, STW_COND, WORLD_HAS_STOPPED};
 
 static GC_START: AtomicU64 = AtomicU64::new(0);
+static CURRENT_GC_MAY_MOVE: AtomicBool = AtomicBool::new(true);
 
 extern "C" {
     pub static jl_gc_disable_counter: AtomicU32;
@@ -31,6 +32,13 @@ impl Collection<JuliaVM> for VMCollection {
         }
 
         trace!("Stopped the world!");
+
+        // Store if the current GC may move objects -- we will use it when the current GC finishes.
+        // We cache the value here just in case MMTk may clear it before we use the value.
+        CURRENT_GC_MAY_MOVE.store(
+            crate::SINGLETON.get_plan().current_gc_may_move_object(),
+            Ordering::SeqCst,
+        );
 
         // Tell MMTk the stacks are ready.
         {
@@ -139,6 +147,10 @@ pub fn is_current_gc_nursery() -> bool {
         Some(gen) => gen.is_current_gc_nursery(),
         None => false,
     }
+}
+
+pub fn is_current_gc_moving() -> bool {
+    CURRENT_GC_MAY_MOVE.load(Ordering::SeqCst)
 }
 
 #[no_mangle]

--- a/mmtk/src/conservative.rs
+++ b/mmtk/src/conservative.rs
@@ -12,17 +12,9 @@ lazy_static! {
     pub static ref CONSERVATIVE_ROOTS: Mutex<HashSet<ObjectReference>> = Mutex::new(HashSet::new());
 }
 
-macro_rules! skip_conservative_scanning_for_non_moving_gc {
-    () => {
-        if !crate::collection::is_current_gc_moving() {
-            return;
-        }
-    };
-}
-
 pub fn pin_conservative_roots() {
-    crate::early_return_for_non_moving!(());
-    skip_conservative_scanning_for_non_moving_gc!();
+    crate::early_return_for_non_moving_build!(());
+    crate::early_return_for_current_gc!();
 
     let mut roots = CONSERVATIVE_ROOTS.lock().unwrap();
     let n_roots = roots.len();
@@ -32,8 +24,8 @@ pub fn pin_conservative_roots() {
 }
 
 pub fn unpin_conservative_roots() {
-    crate::early_return_for_non_moving!(());
-    skip_conservative_scanning_for_non_moving_gc!();
+    crate::early_return_for_non_moving_build!(());
+    crate::early_return_for_current_gc!();
 
     let mut roots = CONSERVATIVE_ROOTS.lock().unwrap();
     let n_pinned = roots.len();
@@ -59,8 +51,8 @@ pub fn mmtk_conservative_scan_task_stack(
     ta: *const mmtk_jl_task_t,
     buffer: &mut Vec<ObjectReference>,
 ) {
-    crate::early_return_for_non_moving!(());
-    skip_conservative_scanning_for_non_moving_gc!();
+    crate::early_return_for_non_moving_build!(());
+    crate::early_return_for_current_gc!();
 
     let mut size: u64 = 0;
     let mut ptid: i32 = 0;
@@ -90,8 +82,8 @@ pub fn mmtk_conservative_scan_ptls_stack(
     ptls: &mut mmtk_jl_tls_states_t,
     buffer: &mut Vec<ObjectReference>,
 ) {
-    crate::early_return_for_non_moving!(());
-    skip_conservative_scanning_for_non_moving_gc!();
+    crate::early_return_for_non_moving_build!(());
+    crate::early_return_for_current_gc!();
 
     let stackbase: Address = Address::from_ptr(ptls.stackbase);
     let stacksize = ptls.stacksize;
@@ -110,8 +102,8 @@ pub fn mmtk_conservative_scan_task_registers(
     ta: *const mmtk_jl_task_t,
     buffer: &mut Vec<ObjectReference>,
 ) {
-    crate::early_return_for_non_moving!(());
-    skip_conservative_scanning_for_non_moving_gc!();
+    crate::early_return_for_non_moving_build!(());
+    crate::early_return_for_current_gc!();
 
     let (lo, hi) = get_range(&unsafe { &*ta }.ctx);
     conservative_scan_range(lo, hi, buffer);
@@ -121,8 +113,8 @@ pub fn mmtk_conservative_scan_ptls_registers(
     ptls: &mut mmtk_jl_tls_states_t,
     buffer: &mut Vec<ObjectReference>,
 ) {
-    crate::early_return_for_non_moving!(());
-    skip_conservative_scanning_for_non_moving_gc!();
+    crate::early_return_for_non_moving_build!(());
+    crate::early_return_for_current_gc!();
 
     let (lo, hi) = get_range(&ptls.ctx_at_the_time_gc_started);
     conservative_scan_range(lo, hi, buffer);

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -129,11 +129,22 @@ pub struct Julia_Upcalls {
 
 pub static mut UPCALLS: *const Julia_Upcalls = null_mut();
 
+/// Skip some methods for a non moving build.
 #[macro_export]
-macro_rules! early_return_for_non_moving {
+macro_rules! early_return_for_non_moving_build {
     ($ret_val:expr) => {
         if cfg!(feature = "non_moving") {
             return $ret_val;
+        }
+    };
+}
+
+/// Skip some methods if the current GC does not move objects
+#[macro_export]
+macro_rules! early_return_for_current_gc {
+    () => {
+        if !crate::collection::is_current_gc_moving() {
+            return;
         }
     };
 }


### PR DESCRIPTION
This PR adds a check for conservative stack scanning: if the current GC does not move objects, the stack scanning will be skipped.