### PR TITLE
Replacing loop over instructions by loop over uses

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "f831a07d94b4d1ce1795bb6f4a34df6570a8eb2e"
+julia_version = "9846195fdbdb6097ef64f06059ef4fd649aed211"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "fcdd215ea98aa09293aac3b246c7b76f87fe43a9"
+julia_repo = "https://github.com/mmtk/julia.git"
+julia_version = "67b2ec10542c9e80d1f5b4aeddb8bf9d3c4f6ba1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "9846195fdbdb6097ef64f06059ef4fd649aed211"
+julia_version = "d7ca89d5017f57b0fedf80add4ae3a0f4aee215e"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "d7ca89d5017f57b0fedf80add4ae3a0f4aee215e"
+julia_version = "fcdd215ea98aa09293aac3b246c7b76f87fe43a9"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 # Metadata for the Julia repository
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
-julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "ddc7361dec25ec618b75e5eb99bea8e59cbdaeaa"
+julia_repo = "https://github.com/udesou/julia.git"
+julia_version = "9448be54cf177efcf315c334f1b2203ef28ca9c7"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/udesou/julia.git"
-julia_version = "9448be54cf177efcf315c334f1b2203ef28ca9c7"
+julia_version = "f831a07d94b4d1ce1795bb6f4a34df6570a8eb2e"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Replacing loop over instructions by loop over uses when running the `lowerGCAllocBytesLate` function.

Merge with https://github.com/mmtk/julia/pull/74.