### PR TITLE
Updating binding code to match VM

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "bc08a9bc1b8574c6aa153656d5758153a5700912"
+julia_version = "4aeea613eba905cdff343213e8f2b006574bd657"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [package.metadata.julia]
 # Our CI matches the following line and extract mmtk/julia. If this line is updated, please check ci yaml files and make sure it works.
 julia_repo = "https://github.com/mmtk/julia.git"
-julia_version = "4aeea613eba905cdff343213e8f2b006574bd657"
+julia_version = "4c940c1b0d6e555b857172176c2805759261e81f"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -61,7 +61,7 @@ extern void mmtk_object_reference_write_post(MMTk_Mutator mutator, const void* s
 extern void mmtk_object_reference_write_slow(MMTk_Mutator mutator, const void* src, const void* target);
 extern const void* MMTK_SIDE_LOG_BIT_BASE_ADDRESS;
 
-extern uintptr_t JULIA_MALLOC_BYTES;
+extern _Atomic(uintptr_t) JULIA_MALLOC_BYTES;
 
 /**
  * Misc

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -101,7 +101,7 @@ extern "C" {
     pub fn jl_throw_out_of_memory_error();
     pub fn jl_get_gc_disable_counter() -> u32;
     pub fn jl_gc_mmtk_sweep_malloced_memory();
-    pub fn jl_gc_mmtk_sweep_stack_pools();
+    pub fn jl_gc_sweep_stack_pools_and_mtarraylist_buffers();
     pub fn jl_hrtime() -> u64;
     pub fn jl_gc_update_stats(t: u64, mmtk_live_bytes: usize, is_nursery: bool);
     pub fn jl_gc_get_abi_structs_checksum_c() -> usize;

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -14,7 +14,7 @@ use mmtk::Mutator;
 use mmtk::MMTK;
 
 use crate::jl_gc_mmtk_sweep_malloced_memory;
-use crate::jl_gc_mmtk_sweep_stack_pools;
+use crate::jl_gc_sweep_stack_pools_and_mtarraylist_buffers;
 use crate::jl_gc_scan_vm_specific_roots;
 use crate::JuliaVM;
 
@@ -218,7 +218,7 @@ impl<VM: VMBinding> GCWork<VM> for SweepVMSpecific {
     fn do_work(&mut self, _worker: &mut GCWorker<VM>, _mmtk: &'static MMTK<VM>) {
         // call sweep malloced arrays and sweep stack pools
         unsafe { jl_gc_mmtk_sweep_malloced_memory() }
-        unsafe { jl_gc_mmtk_sweep_stack_pools() }
+        unsafe { jl_gc_sweep_stack_pools_and_mtarraylist_buffers() }
         self.swept = true;
     }
 }

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -14,8 +14,8 @@ use mmtk::Mutator;
 use mmtk::MMTK;
 
 use crate::jl_gc_mmtk_sweep_malloced_memory;
-use crate::jl_gc_sweep_stack_pools_and_mtarraylist_buffers;
 use crate::jl_gc_scan_vm_specific_roots;
+use crate::jl_gc_sweep_stack_pools_and_mtarraylist_buffers;
 use crate::JuliaVM;
 
 pub struct VMScanning {}


### PR DESCRIPTION
Updating `julia_version` to point to the latest commit of https://github.com/mmtk/julia/tree/upstream-ready/immix.