### PR TITLE
Abort for GC thread panic

### DIFF
--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -95,6 +95,9 @@ pub extern "C" fn mmtk_gc_init(
     // Make sure we initialize MMTk here
     lazy_static::initialize(&SINGLETON);
 
+    // Hijack the panic hook to make sure that if we crash in the GC threads, the process aborts.
+    crate::set_panic_hook();
+
     // Assert to make sure our fastpath allocation is correct.
     {
         // If the assertion failed, check the allocation fastpath in Julia


### PR DESCRIPTION
The code is mainly from `mmrk-ruby`. We hijack the Rust panic hook to make sure that if the GC threads panic, the process will be aborted. The current behavior is that when a GC thread panics, the process hangs and wait for that GC thread to finish its work.

This should be ported to `master`.