### PR TITLE
Always conservatively scan task stacks. Fix get_lo_object_size

### DIFF
--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -315,7 +315,7 @@ pub unsafe fn get_so_object_size(object: ObjectReference) -> usize {
 #[inline(always)]
 pub unsafe fn get_lo_object_size(object: ObjectReference) -> usize {
     let obj_address = object.to_raw_address();
-    let julia_big_object = obj_address.to_ptr::<_bigval_t>();
+    let julia_big_object = (obj_address - std::mem::size_of::<_bigval_t>()).to_ptr::<_bigval_t>();
     (*julia_big_object).sz
 }
 

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -84,11 +84,11 @@ impl Scanning<JuliaVM> for VMScanning {
                     pthread
                 );
                 // Conservative scan stack and registers. If the task hasn't been started, we do not need to scan its stack and registers.
+                // Note: we tried to skip the conservative scanning if the task is not started (task.start). However, it turned out that
+                // the stack may be used by the runtime before the task is started. So we have to scan the stack conservatively.
                 unsafe {
-                    if (*task).start == crate::jl_true {
-                        crate::conservative::mmtk_conservative_scan_task_stack(task);
-                        crate::conservative::mmtk_conservative_scan_task_registers(task);
-                    }
+                    crate::conservative::mmtk_conservative_scan_task_stack(task);
+                    crate::conservative::mmtk_conservative_scan_task_registers(task);
                 }
 
                 if task_is_root {


### PR DESCRIPTION
1. Do not skip conservative scanning based on task.start. 
2. Fix `get_lo_object_size`