### PR TITLE
Fix possible typo in mmtk_is_pointer_pinned

### DIFF
--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -612,7 +612,7 @@ pub extern "C" fn mmtk_is_pointer_pinned(addr: Address) -> bool {
 
     if crate::object_model::is_addr_in_immixspace(addr) {
         handle_potential_internal_pointer!(memory_manager::is_pinned, addr)
-    } else if !mmtk_object_is_managed_by_mmtk(addr.as_usize()) {
+    } else if mmtk_object_is_managed_by_mmtk(addr.as_usize()) {
         debug!(
             "Object is not in Immix space. MMTk will not move the object. We assume it is pinned."
         );


### PR DESCRIPTION
Seems like a typo: it looks like the `if else`  branch should be handling objects that are managed by MMTk, but that are not in IMMIX space.