### PR TITLE
expose mmtk_get_base_pointer in the binding

### DIFF
--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -52,6 +52,7 @@ extern void mmtk_unreachable(void);
 extern unsigned char mmtk_pin_object(void* obj);
 extern unsigned char mmtk_unpin_object(void* obj);
 extern bool mmtk_is_object_pinned(void* obj);
+extern void* mmtk_get_base_pointer(void* ptr);
 extern unsigned char mmtk_pin_pointer(void* ptr);
 extern bool mmtk_is_pointer_pinned(void* ptr);
 extern const char* get_mmtk_version(void);

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -583,6 +583,14 @@ macro_rules! handle_potential_internal_pointer {
 }
 
 #[no_mangle]
+pub extern "C" fn mmtk_get_base_pointer(addr: Address) -> Address {
+    if let Some(obj) = memory_manager::find_object_from_internal_pointer(addr, usize::MAX) {
+        return obj.to_raw_address();
+    }
+    Address::ZERO
+}
+
+#[no_mangle]
 pub extern "C" fn mmtk_pin_pointer(addr: Address) -> bool {
     crate::early_return_for_non_moving_build!(false);
 


### PR DESCRIPTION
We'll need this for the pinning profiler.

We want to track which object was pinned when we called `ptr_pin` on a possibly internal pointer.