### PR TITLE
Applying cargo fmt and refactoring scanning code further

### DIFF
--- a/mmtk/src/conservative.rs
+++ b/mmtk/src/conservative.rs
@@ -1,5 +1,5 @@
-use crate::julia_types::*;
 use crate::jl_log_pinning_event;
+use crate::julia_types::*;
 use mmtk::memory_manager;
 use mmtk::util::constants::BYTES_IN_ADDRESS;
 use mmtk::util::{Address, ObjectReference};


### PR DESCRIPTION
Running `cargo fmt`, fixing some warnings and rewriting a few other pieces of code in the object scanning function following from https://github.com/mmtk/mmtk-julia/pull/253.