### PR TITLE
Assert collection is enabled when GC starts

### DIFF
--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -59,6 +59,8 @@ impl Collection<JuliaVM> for VMCollection {
             // FIXME add wait var
         }
 
+        assert!(Self::is_collection_enabled(), "Collection is disabled when threads are stopped for a GC. This is a concurrency bug, see https://github.com/mmtk/mmtk-julia/issues/278.");
+
         trace!("Stopped the world!");
         #[cfg(feature = "heap_dump")]
         dump_heap(GC_COUNT.load(Ordering::SeqCst), 0);


### PR DESCRIPTION
This PR adds an assertion to check if GC is always enabled when we stop threads for a GC. If we see this assertion fail, we will know it is related with https://github.com/mmtk/mmtk-julia/issues/278.