### PR TITLE
Make MMTk recognize pointers to object ends as internal pointers

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -610,7 +610,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mmtk"
 version = "0.31.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=ceea8cf9e4aca52220c674b8a95b4bc5ae0adcae#ceea8cf9e4aca52220c674b8a95b4bc5ae0adcae"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=cc630f0abd524c3c10dab79c58ee4589bc4b67e8#cc630f0abd524c3c10dab79c58ee4589bc4b67e8"
 dependencies = [
  "atomic 0.6.0",
  "atomic-traits",
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.31.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=ceea8cf9e4aca52220c674b8a95b4bc5ae0adcae#ceea8cf9e4aca52220c674b8a95b4bc5ae0adcae"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=cc630f0abd524c3c10dab79c58ee4589bc4b67e8#cc630f0abd524c3c10dab79c58ee4589bc4b67e8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "ceea8cf9e4aca52220c674b8a95b4bc5ae0adcae" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "cc630f0abd524c3c10dab79c58ee4589bc4b67e8" }
 # Uncomment the following to build locally
 # mmtk = { path = "../../mmtk-core" }
 log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] }
@@ -42,7 +42,7 @@ json = "0.12.4"
 
 [features]
 # We must build with default features
-default = ["mmtk/vm_space", "julia_copy_stack", "mmtk/object_pinning", "mmtk/is_mmtk_object", "mmtk/vo_bit_access", "address_based_hashing"]#, "heap_dump"]#, "dump_memory_stats"]
+default = ["mmtk/vm_space", "julia_copy_stack", "mmtk/object_pinning", "mmtk/is_mmtk_object", "mmtk/vo_bit_access", "address_based_hashing", "mmtk/object_end_internal_pointer"]#, "heap_dump"]#, "dump_memory_stats"]
 
 # Default features
 julia_copy_stack = []


### PR DESCRIPTION
See https://github.com/mmtk/mmtk-core/pull/1410. For types like `(true, ())`, the length of the object is 9 bytes (including a 8-byte header). So the field `()` is 0-size at the end of the object, and an internal pointer to it actually points outside the allocated memory for this object. In such case, MMTk does not consider it as an internal pointer.

One example is https://github.com/mmtk/julia/blob/10c2bb0a05530e0c0fdca9b04d8321440267216c/src/staticdata.c#L1766 where the runtime iterates through all the fields and `slot` can point to a `()` field at the end of an object. MMTk core does not consider it as an internal pointer, as it points to the memory outside the object. If we intend to use address based hashing for htables, the above code needs to find the base object for `slot` and find the stored hash for the base object. It is necessary for MMTk to correctly consider it as an internal pointer, and be able to find the base object.