### PR TITLE
Set count_live_bytes_in_gc option when print_fragmentation is enabled

### DIFF
--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -101,6 +101,11 @@ pub extern "C" fn mmtk_gc_init(
             let success = builder.options.threads.set(n_gcthreads);
             assert!(success, "Failed to set GC threads to {}", n_gcthreads);
         }
+
+        if cfg!(feature = "print_fragmentation") {
+            let success = builder.options.count_live_bytes_in_gc.set(true);
+            assert!(success, "Failed to enable live byte counting in GC");
+        }
     }
 
     // Make sure that we haven't initialized MMTk (by accident) yet
@@ -643,7 +648,7 @@ pub extern "C" fn get_mmtk_version() -> *const c_char {
 pub extern "C" fn print_fragmentation() {
     let map = memory_manager::live_bytes_in_last_gc(&SINGLETON);
     for (space, stats) in map {
-        println!(
+        eprintln!(
             "Utilization in space {:?}: {} live bytes, {} total bytes, {:.2} %",
             space,
             stats.live_bytes,


### PR DESCRIPTION
When `print_fragmentation` is enabled, set the MMTk option `count_live_bytes_in_gc`. Otherwise MMTk will not collect fragmentation data, and the binding will not print anything.

Print fragmentation data with stderr.