### PR TITLE
Declare side metadata base address in the Julia repo

### DIFF
--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -59,8 +59,6 @@ extern void mmtk_immortal_region_post_alloc(void* addr, size_t size);
 extern void mmtk_memory_region_copy(MMTk_Mutator mutator, void* src_obj, void* src_addr, void* dst_obj, void* dst_addr, size_t size);
 extern void mmtk_object_reference_write_post(MMTk_Mutator mutator, const void* src, const void* target);
 extern void mmtk_object_reference_write_slow(MMTk_Mutator mutator, const void* src, const void* target);
-extern void* MMTK_SIDE_LOG_BIT_BASE_ADDRESS;
-
 extern _Atomic(uintptr_t) JULIA_MALLOC_BYTES;
 
 /**

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -428,7 +428,6 @@ pub extern "C" fn mmtk_object_reference_write_slow(
     );
 }
 
-
 #[no_mangle]
 pub extern "C" fn mmtk_object_is_managed_by_mmtk(addr: usize) -> bool {
     crate::api::mmtk_is_mapped_address(unsafe { Address::from_usize(addr) })

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 use crate::JuliaVM;
 use crate::JULIA_HEADER_SIZE;
+use crate::MMTK_SIDE_LOG_BIT_BASE_ADDRESS;
 use crate::SINGLETON;
 use crate::{BUILDER, DISABLED_GC, MUTATORS, USER_TRIGGERED_GC};
 
@@ -427,9 +428,6 @@ pub extern "C" fn mmtk_object_reference_write_slow(
     );
 }
 
-/// Runtime base address for Julia's side log bit metadata fast path.
-#[no_mangle]
-pub static mut MMTK_SIDE_LOG_BIT_BASE_ADDRESS: Address = Address::ZERO;
 
 #[no_mangle]
 pub extern "C" fn mmtk_object_is_managed_by_mmtk(addr: usize) -> bool {

--- a/mmtk/src/julia_types.rs
+++ b/mmtk/src/julia_types.rs
@@ -2202,15 +2202,15 @@ pub struct _jl_handler_t {
     pub gcstack: *mut jl_gcframe_t,
     pub scope: *mut jl_value_t,
     pub prev: *mut _jl_handler_t,
-    pub gc_state: i8,
     pub locks_len: usize,
-    pub defer_signal: sig_atomic_t,
     pub timing_stack: *mut jl_timing_block_t,
     pub world_age: usize,
+    pub defer_signal: sig_atomic_t,
+    pub gc_state: i8,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of _jl_handler_t"][::std::mem::size_of::<_jl_handler_t>() - 264usize];
+    ["Size of _jl_handler_t"][::std::mem::size_of::<_jl_handler_t>() - 256usize];
     ["Alignment of _jl_handler_t"][::std::mem::align_of::<_jl_handler_t>() - 8usize];
     ["Offset of field: _jl_handler_t::eh_ctx"]
         [::std::mem::offset_of!(_jl_handler_t, eh_ctx) - 0usize];
@@ -2220,16 +2220,16 @@ const _: () = {
         [::std::mem::offset_of!(_jl_handler_t, scope) - 208usize];
     ["Offset of field: _jl_handler_t::prev"]
         [::std::mem::offset_of!(_jl_handler_t, prev) - 216usize];
-    ["Offset of field: _jl_handler_t::gc_state"]
-        [::std::mem::offset_of!(_jl_handler_t, gc_state) - 224usize];
     ["Offset of field: _jl_handler_t::locks_len"]
-        [::std::mem::offset_of!(_jl_handler_t, locks_len) - 232usize];
-    ["Offset of field: _jl_handler_t::defer_signal"]
-        [::std::mem::offset_of!(_jl_handler_t, defer_signal) - 240usize];
+        [::std::mem::offset_of!(_jl_handler_t, locks_len) - 224usize];
     ["Offset of field: _jl_handler_t::timing_stack"]
-        [::std::mem::offset_of!(_jl_handler_t, timing_stack) - 248usize];
+        [::std::mem::offset_of!(_jl_handler_t, timing_stack) - 232usize];
     ["Offset of field: _jl_handler_t::world_age"]
-        [::std::mem::offset_of!(_jl_handler_t, world_age) - 256usize];
+        [::std::mem::offset_of!(_jl_handler_t, world_age) - 240usize];
+    ["Offset of field: _jl_handler_t::defer_signal"]
+        [::std::mem::offset_of!(_jl_handler_t, defer_signal) - 248usize];
+    ["Offset of field: _jl_handler_t::gc_state"]
+        [::std::mem::offset_of!(_jl_handler_t, gc_state) - 252usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -121,6 +121,7 @@ extern "C" {
     pub fn jl_gc_get_owner_address_to_mmtk(m: Address) -> Address;
     pub fn jl_gc_genericmemory_how(m: Address) -> usize;
     pub fn jl_gc_get_max_memory() -> usize;
+    pub static mut MMTK_SIDE_LOG_BIT_BASE_ADDRESS: Address;
 }
 
 pub(crate) fn set_panic_hook() {


### PR DESCRIPTION
Currently `MMTK_SIDE_LOG_BIT_BASE_ADDRESS` is defined in the binding side. When we embed this symbol in the JIT code, Julia needs to be able to resolve to the variable. This PR moves it to the Julia side. This PR needs https://github.com/JuliaLang/julia/pull/61769 to work.