### PR TITLE
Check typeeq for object size. Minor refactoring

### DIFF
--- a/mmtk/src/julia_scanning.rs
+++ b/mmtk/src/julia_scanning.rs
@@ -84,22 +84,7 @@ pub unsafe fn scan_julia_object<SV: SlotVisitor<JuliaVMSlot>>(obj: Address, clos
         return;
     }
 
-    if vtag_usize == ((jl_small_typeof_tags_jl_datatype_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_unionall_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_uniontype_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_typeeq_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_tvar_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_vararg_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_globalref_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_gotoifnot_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_returnnode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_enternode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_pinode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_phinode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_phicnode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_upsilonnode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_quotenode_tag as usize) << 4)
-    {
+    if crate::object_model::is_small_typeof_tag_with_no_pointer(vtag_usize) {
         // these objects have pointers in them, but no other special handling
         // so we want these to fall through to the end
         vtag_usize = jl_small_typeof[vtag.as_usize() / std::mem::size_of::<Address>()] as usize;

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -186,21 +186,7 @@ pub unsafe fn get_so_object_size(object: ObjectReference) -> usize {
         return mmtk_get_obj_size(object);
     }
 
-    if vtag_usize == ((jl_small_typeof_tags_jl_datatype_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_unionall_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_uniontype_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_tvar_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_vararg_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_globalref_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_gotoifnot_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_returnnode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_enternode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_pinode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_phinode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_phicnode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_upsilonnode_tag as usize) << 4)
-        || vtag_usize == ((jl_small_typeof_tags_jl_quotenode_tag as usize) << 4)
-    {
+    if is_small_typeof_tag_with_no_pointer(vtag_usize) {
         // these objects have pointers in them, but no other special handling
         // so we want these to fall through to the end
         vtag_usize = jl_small_typeof[vtag.as_usize() / std::mem::size_of::<Address>()] as usize;
@@ -333,4 +319,23 @@ pub unsafe fn llt_align(size: usize, align: usize) -> usize {
 pub unsafe fn mmtk_jl_is_uniontype(t: *const jl_datatype_t) -> bool {
     mmtk_jl_typetagof(Address::from_ptr(t)).as_usize()
         == (jl_small_typeof_tags_jl_uniontype_tag << 4) as usize
+}
+
+#[inline(always)]
+pub fn is_small_typeof_tag_with_no_pointer(vtag: usize) -> bool {
+    vtag == ((jl_small_typeof_tags_jl_datatype_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_unionall_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_uniontype_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_typeeq_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_tvar_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_vararg_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_globalref_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_gotoifnot_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_returnnode_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_enternode_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_pinode_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_phinode_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_phicnode_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_upsilonnode_tag as usize) << 4)
+        || vtag == ((jl_small_typeof_tags_jl_quotenode_tag as usize) << 4)
 }


### PR DESCRIPTION
This PR fixes typeeq for object size, and includes minor refactoring to remove duplicate code