### PR TITLE
Add `mmtk_collection_in_progress` C API

### DIFF
--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -180,3 +180,20 @@ pub extern "C" fn mmtk_block_thread_for_gc() {
 
     AtomicIsize::store(&USER_TRIGGERED_GC, 0, Ordering::SeqCst);
 }
+
+/// True iff a GC cycle is currently in progress: either a stop-the-world pause is
+/// happening or a (potentially concurrent) mark / sweep phase is active.
+#[no_mangle]
+pub extern "C" fn mmtk_collection_in_progress() -> bool {
+    if AtomicBool::load(&WORLD_HAS_STOPPED, Ordering::SeqCst)
+        || AtomicBool::load(&BLOCK_FOR_GC, Ordering::SeqCst)
+    {
+        return true;
+    }
+    if let Some(c) = SINGLETON.get_plan().concurrent() {
+        if c.concurrent_work_in_progress() || c.current_pause().is_some() {
+            return true;
+        }
+    }
+    false
+}


### PR DESCRIPTION
This API seems sufficient for Julia to implement a "disable-GC-and-wait-for-finish" API, e.g.:
```c
JL_DLLEXPORT void jl_gc_wait_until_disabled(jl_ptls_t ptls)
{
    while (mmtk_collection_in_progress()) {
        mmtk_gc_poll(ptls);
        jl_cpu_pause();
    }
}
```

Effectively spinlocking on this condition is not great, but I am OK with cleaning that up in a future re-factor.

I'd also be fine to implement https://github.com/mmtk/mmtk-julia/pull/301/ or another re-factor instead.

The only trouble is that those APIs seem to focus on disabling GC triggers or disabling GC stop-the-world, which is not sufficient for true GC-must-not-run critical sections. This API is intended to be used if you want to disable new GC and are willing to wait for ongoing GC to finish to make sure it is not running at all.